### PR TITLE
chore(post-migration): batch audit relaxation, #56 closure, and 3 lint fixes

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 const NotFound = () => {
   return (
@@ -16,12 +17,12 @@ const NotFound = () => {
           </p>
 
           <div className='flex items-center mt-6 gap-x-3'>
-            <a
+            <Link
               href='/'
               className='w-1/2 px-5 py-2 text-sm tracking-wide text-white transition-colors duration-200 bg-blue-500 rounded-lg shrink-0 sm:w-auto hover:bg-blue-600 dark:hover:bg-blue-500 dark:bg-blue-600'
             >
               Take me home
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/components/ModeToggle.tsx
+++ b/components/ModeToggle.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 import { BsSunFill, BsMoonFill } from 'react-icons/bs';
-export function ModeToggle() {
-  const [mounted, setMounted] = useState<Boolean>(false);
-  const { theme, setTheme } = useTheme();
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+const emptySubscribe = () => () => {};
+
+export function ModeToggle() {
+  const mounted = useSyncExternalStore(
+    emptySubscribe,
+    () => true,
+    () => false
+  );
+  const { theme, setTheme } = useTheme();
 
   if (!mounted) return null;
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { ModeToggle } from './ModeToggle';
 
 const Navigation = () => {
@@ -9,12 +10,12 @@ const Navigation = () => {
   return (
     <nav className='sticky top-0 z-[100] w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200/50 dark:border-gray-700/50 px-6 py-3 transition-all duration-300'>
       <div className='flex flex-wrap items-center justify-between'>
-        <a
+        <Link
           href='/'
           className='self-center text-2xl font-semibold text-transparent bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 bg-clip-text md:text-4xl lg:text-3xl'
         >
           Yunior B.
-        </a>
+        </Link>
         <div className='flex items-center space-x-8'>
           <ModeToggle />
           <button


### PR DESCRIPTION
## Overview

Batches the post-#57 leftovers into a single PR:

1. **Audit-gate relaxation** — `npm audit --audit-level=high` to `--audit-level=critical`. (Resolved in the merged #57 via an in-PR edit, so the gate is now `@audit-level=critical` on `main`.)
2. **PR #56 closure** — `@opentelemetry/core` + `@sentry/nextjs` Dependabot PR. Resolved as obsolete after PRs #50–55 merged; PR #56 was closed during the merge cycle.
3. **The 3 remaining lint violations** flagged by the new ESLint 9 flat config:
   - `app/not-found.tsx` — swap `<a href="/">` for `<Link>` (rule `@next/next/no-html-link-for-pages`).
   - `components/Navigation.tsx` — swap the brand `<a href="/">` for `<Link>`; the `#projects` and `#contact` in-page anchors are intentionally left as native `<a>` (not flagged by the rule).
   - `components/ModeToggle.tsx` — replace the `useState<boolean>(false)` + `useEffect(() => setMounted(true), [])` mounted-flag pattern (flagged by `react-hooks/set-state-in-effect`) with `useSyncExternalStore(emptySubscribe, () => true, () => false)`.

## Note on this PR's provenance

The original PR for this work was #70. During a clean rename of the source branch (`fix/lint-findings` → `chore/post-migration-cleanup`), GitHub auto-closed #70 because deleting the source branch triggers PR closure. This PR is the reopen with identical commits. See #70 for the original CI pass: `audit` (SUCCESS), `dependency-review` (SUCCESS), `auto-update-next` (SKIPPED), `Vercel` (PENDING — preview only).

## Verification (local)

- `npx tsc --noEmit` — pass
- `npx jest --watchAll=false` — pass (3 suites / 10 tests)
- `npm run build` — pass

## Scope-kept

No `.gitattributes` normalization or `core.autocrlf` policy change in this PR — was deliberately excluded. If we want a follow-up PR to lock line endings project-wide, that's a separate, focused effort.

Closes #70 (reopen-as-new since #70 was auto-closed by source-branch deletion).
