### PR TITLE
fix(lint): the 3 violations from the flat-config migration (Link swaps + useSyncExternalStore)

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import Link from 'next/link';
 
 const NotFound = () => {
   return (
@@ -16,12 +17,12 @@ const NotFound = () => {
           </p>
 
           <div className='flex items-center mt-6 gap-x-3'>
-            <a
+            <Link
               href='/'
               className='w-1/2 px-5 py-2 text-sm tracking-wide text-white transition-colors duration-200 bg-blue-500 rounded-lg shrink-0 sm:w-auto hover:bg-blue-600 dark:hover:bg-blue-500 dark:bg-blue-600'
             >
               Take me home
-            </a>
+            </Link>
           </div>
         </div>
 

--- a/components/ModeToggle.tsx
+++ b/components/ModeToggle.tsx
@@ -1,15 +1,14 @@
 'use client';
 
 import { useTheme } from 'next-themes';
-import { useState, useEffect } from 'react';
+import { useSyncExternalStore } from 'react';
 import { BsSunFill, BsMoonFill } from 'react-icons/bs';
-export function ModeToggle() {
-  const [mounted, setMounted] = useState<Boolean>(false);
-  const { theme, setTheme } = useTheme();
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+const emptySubscribe = () => () => {};
+
+export function ModeToggle() {
+  const mounted = useSyncExternalStore(emptySubscribe, () => true, () => false);
+  const { theme, setTheme } = useTheme();
 
   if (!mounted) return null;
 

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import Link from 'next/link';
 import { ModeToggle } from './ModeToggle';
 
 const Navigation = () => {
@@ -9,12 +10,12 @@ const Navigation = () => {
   return (
     <nav className='sticky top-0 z-[100] w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-md border-b border-gray-200/50 dark:border-gray-700/50 px-6 py-3 transition-all duration-300'>
       <div className='flex flex-wrap items-center justify-between'>
-        <a
+        <Link
           href='/'
           className='self-center text-2xl font-semibold text-transparent bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 bg-clip-text md:text-4xl lg:text-3xl'
         >
           Yunior B.
-        </a>
+        </Link>
         <div className='flex items-center space-x-8'>
           <ModeToggle />
           <button


### PR DESCRIPTION
## What

Three small lint fixes surfaced by the new ESLint 9 flat config (after #57 + #59 + the merged Dependabot batch landed):

1. **`app/not-found.tsx`** — replaced `<a href="/">Take me home</a>` with `<Link href="/">…</Link>` (Next.js rule `@next/next/no-html-link-for-pages`).
2. **`components/Navigation.tsx`** — replaced only the home brand link `<a href="/">Yunior B.</a>` with `<Link>`. The in-page `#projects` and `#contact` anchors stay native `<a>` (not flagged, and `<Link>` isn't useful for hash jumps).
3. **`components/ModeToggle.tsx`** — replaced the `useState<Boolean>(false)` + `useEffect(() => setMounted(true), [])` mounted-flag pattern (flagged by `react-hooks/set-state-in-effect`) with `useSyncExternalStore(emptySubscribe, () => true, () => false)`. `emptySubscribe = () => () => {}` is hoisted at module scope so its identity is stable across renders; the `() => true` / `() => false` snapshots return primitives that pass React's `Object.is` equality check.

## Why a separate PR from #71

PR #71 (`chore/post-migration-cleanup`) bundles these same 3 fixes but framed the branch more broadly (audit-gate relaxation + #56 closure + 3 lint fixes). This PR is the focused, minimal-scope version the user specifically asked for: just the 3 lint findings, on a `fix/lint-findings` branch.

## Verification (local)

- `npx tsc --noEmit` — pass
- `npx jest` — 3 suites / 10 tests pass
- `npm run build` — pass, all 7 static pages generated
- `npx eslint app/not-found.tsx components/Navigation.tsx components/ModeToggle.tsx` — the 3 named rule violations are gone

## Out of scope (intentionally excluded)

- Prettier `endOfLine: "lf"` normalization on the test/mocks/next.config.js files (~170 unrelated CRLF errors). The `.gitattributes` policy fix and LF normalization are deliberately separate work.
- The `@svgr/webpack` + `file-loader` cleanup on `next.config.js` (already shipped via #63).
