### PR TITLE
test: add /api/contact validation regression net

### DIFF
--- a/__tests__/contact-route.test.ts
+++ b/__tests__/contact-route.test.ts
@@ -1,0 +1,65 @@
+/** @jest-environment node */
+
+import { afterAll, beforeAll, describe, expect, test } from '@jest/globals';
+
+import { POST } from '../app/api/contact/route';
+
+/**
+ * Regression net for /api/contact's request-validation branch. Captures the
+ * SWC-compiled behavior so a future babel-toolchain or SWC-version pin
+ * regression surfaces as a test failure here instead of a prod 500.
+ *
+ * Per app/api/contact/route.ts the validation chain is:
+ *   1. MAILJET_API_KEY / MAILJET_SECRET_KEY env check  -> if missing: 500
+ *   2. Body parsed and field-validated                 -> if any of
+ *      full_name/email/textarea is missing: 400 + { error: 'Missing required fields' }
+ *   3. (out of scope for this net) Mailjet API call   -> success 200 / fail 500
+ *
+ * Tests in this file deliberately target step 2 only \u2014 the validation branch
+ * that has no external dependencies (no fetch, no Mailjet credentials) so the
+ * test surface is minimal and CI-stable.
+ */
+
+const SAVED_API_KEY = process.env.MAILJET_API_KEY;
+const SAVED_SECRET_KEY = process.env.MAILJET_SECRET_KEY;
+
+beforeAll(() => {
+  // Pre-set MAILJET env so the route reaches the body-validation branch
+  // instead of returning 500 'Email service not configured'.
+  process.env.MAILJET_API_KEY = 'test-fake-not-real';
+  process.env.MAILJET_SECRET_KEY = 'test-fake-not-real';
+});
+
+afterAll(() => {
+  if (SAVED_API_KEY !== undefined) process.env.MAILJET_API_KEY = SAVED_API_KEY;
+  if (SAVED_SECRET_KEY !== undefined)
+    process.env.MAILJET_SECRET_KEY = SAVED_SECRET_KEY;
+});
+
+const buildRequest = (body: unknown): Request =>
+  new Request('http://localhost:3000/api/contact', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+interface ErrorBody {
+  error: string;
+}
+
+describe('POST /api/contact \u2014 field validation', () => {
+  test.each([
+    { label: 'full_name', body: { email: 'x@y.z', textarea: 'hi' } },
+    { label: 'email', body: { full_name: 'Test User', textarea: 'hi' } },
+    { label: 'textarea', body: { full_name: 'Test User', email: 'x@y.z' } },
+    { label: 'all fields', body: {} },
+  ])(
+    'returns 400 with { error: "Missing required fields" } when $label is missing',
+    async ({ body }) => {
+      const response = await POST(buildRequest(body));
+      expect(response.status).toBe(400);
+      const result = (await response.json()) as ErrorBody;
+      expect(result).toEqual({ error: 'Missing required fields' });
+    }
+  );
+});


### PR DESCRIPTION
## /api/contact field-validation regression net

Covers the SWC-compiled validation-response shape as a CI gate so a future
babel-toolchain or SWC-version pin regression surfaces as a test failure
here instead of a prod 500.

### What it does

`__tests__/contact-route.test.ts` runs 4 missing-field permutations against
the route handler's POST entry point. Each permutation asserts:

- HTTP status 400
- JSON body matches `{ error: 'Missing required fields' }` (byte-exact)

### Why a docblock override

```
/** @jest-environment node */
```

The project-level `jest.config.js` sets `testEnvironment: 'jest-environment-jsdom'`
(via `next/jest`). jsdom v26 (shipped with `jest-environment-jsdom@30`) provides
DOM globals (`HTMLElement`, `IntersectionObserver` mocks, etc.) but DOES NOT
expose the Web `Request` / `Response` constructors. The route handler at
`app/api/contact/route.ts` uses both natively:

```ts
const body = await req.json();            // Web API on real Request
return new Response(JSON.stringify(...),  // Web API on real Response
  { status: 400 });
```

The docblock forces jest to use the `node` environment for THIS single file,
where `Request` / `Response` / `Buffer` / `process.env` are native globals via
Node 22's built-in undici integration. Existing component tests
(`__tests__/About.test.js`, `__tests__/Home.test.js`, `__tests__/Hero.test.js`)
keep `jest-environment-jsdom` because they need DOM globals.

This is the canonical jest pattern for testing server-side / Web-API code paths
under a project whose default test env is jsdom. No project-config change.

### Coverage scope (deliberate)

This file targets the **field-validation branch** of the route only \u2014 step 2
in:

1. MAILJET_API_KEY / MAILJET_SECRET_KEY env check   \u2192 if missing: 500
2. Body parsed + field-validated                     \u2192 if missing: 400  *(this net's scope)*
3. Mailjet fetch + HTML scaffold                     \u2192 success: 200  *(not covered here)*

Step 1 requires broader jest env-snapshot machinery; step 3 requires
`jest.spyOn(global, 'fetch').mockResolvedValue(...)`. Both are deliberately
out-of-scope for this minimal regression net per the code-reviewer's
coverage-gap note; they can be added in a follow-up PR if the SWC regression
risk surface needs the wider coverage.

### Verification

```
$ npm run lint:check    -> exit 0
$ npx tsc --noEmit      -> exit 0
$ npx jest --watchAll=false --no-colors
   Test Suites: 4 passed, 4 total
   Tests:       14 passed, 14 total  (10 pre-existing + 4 new)
$ npm run build                  -> exit 0
$ npm audit --omit=dev --audit-level=critical  -> exit 0
```

### Diff

```
1 file changed, +63 insertions(?)
__tests__/contact-route.test.ts  (new)
```

