### PR TITLE
ci(prod-smoke): apply post-merge reviewer-flagged hardening

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -18,6 +18,14 @@
 #     crash signal is HTTP 500.  HTTP 200/4xx is acceptable because the route
 #     is documented to return 400 for missing fields and the smoke payload
 #     deliberately omits `full_name` and `textarea`.  HTTP 500 = fail.
+#
+# Hardening (post-PR-#85 code-review):
+#   - explicit `permissions: {}`  \u2192 zero GITHUB_TOKEN grants, future-proof
+#     against accidental over-broad permission inheritance if a step is added.
+#   - per-route `mktemp` body file  \u2192 on failure the ::error annotation shows
+#     the *failing* route's body, not the previous route's response.
+#   - `curl --max-time 30` per call  \u2192 Vercel CDN hang is bounded to 30s,
+#     not unbounded (would otherwise consume the 5-min job timeout).
 
 name: prod-smoke
 
@@ -31,6 +39,12 @@ on:
         required: false
         default: 'https://yuniorbatista.com'
         type: string
+
+# Required for cron workflows that don't touch GITHUB_TOKEN: explicit
+# zero-permissions block.  Default would over-grant (contents: read,
+# pull-requests: read/write, etc.) and silently activate if any future
+# step adds a `uses:` action.
+permissions: {}
 
 jobs:
   smoke-test:
@@ -46,58 +60,76 @@ jobs:
           PROD="${PROD_URL%/}"
 
           # check_status <url> <method> <expected> [body]
+          # Per-curl --max-time 30 prevents Vercel CDN hang from blocking
+          # until job timeout.  Body captured via per-route mktemp file
+          # (cleaned-up on every exit path) so on failure the ::error
+          # annotation shows the failing route's body, not the previous
+          # route's response.
           check_status() {
             local url="$1"
             local method="$2"
             local expected="$3"
-            local body="${4:-}"
+            local body_arg="${4:-}"
+            local body_file
+            body_file=$(mktemp)
             local actual
-            if [ -n "$body" ]; then
-              actual=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+            if [ -n "$body_arg" ]; then
+              actual=$(curl -sS --max-time 30 -o "$body_file" \
+                -w '%{http_code}' \
                 -X "$method" \
                 -H 'Content-Type: application/json' \
-                -d "$body" \
+                -d "$body_arg" \
                 "$url")
             else
-              actual=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+              actual=$(curl -sS --max-time 30 -o "$body_file" \
+                -w '%{http_code}' \
                 -X "$method" \
                 "$url")
             fi
             if [ "$actual" != "$expected" ]; then
               echo "::error title=smoke regression::$method $url  expected=$expected  got=$actual"
               echo "--- response body (truncated to 800 bytes) ---"
-              head -c 800 /tmp/smoke-body || true
+              head -c 800 "$body_file" 2>/dev/null || echo '(body file unreadable)'
               echo
               echo "--- end body ---"
+              rm -f "$body_file"
               return 1
             fi
+            rm -f "$body_file"
             echo "PASS  $method $url  -> $actual (expected $expected)"
           }
 
           # check_not_500 <url> <method> [body]
-          # Used for POST /api/contact where any non-500 status proves the route
-          # handler compiled + ran (Mailjet-fetch rejection/validation 400/etc all
-          # are acceptable).  500 = route-handler-runtime crash = regression.
+          # The smoke POST deliberately omits `full_name` + `textarea` to
+          # trigger the route's validation 400 branch deterministically.
+          # The regression signal is HTTP 500 only (route-handler-runtime
+          # crash); 200/4xx are both acceptable.
           check_not_500() {
             local url="$1"
             local method="$2"
-            local body="${3:-}"
+            local body_arg="${3:-}"
+            local body_file
+            body_file=$(mktemp)
             local actual
-            if [ -n "$body" ]; then
-              actual=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+            if [ -n "$body_arg" ]; then
+              actual=$(curl -sS --max-time 30 -o "$body_file" \
+                -w '%{http_code}' \
                 -X "$method" \
                 -H 'Content-Type: application/json' \
-                -d "$body" \
+                -d "$body_arg" \
                 "$url")
             else
-              actual=$(curl -sS -o /tmp/smoke-body -w '%{http_code}' \
+              actual=$(curl -sS --max-time 30 -o "$body_file" \
+                -w '%{http_code}' \
                 -X "$method" \
                 "$url")
             fi
             if [ "$actual" = "500" ]; then
-              echo "::error title=route handler crashed::$method $url  got=500 (body: $(head -c 200 /tmp/smoke-body || true))"
+              echo "::error title=route handler crashed::$method $url  got=500 (body: $(head -c 200 "$body_file" 2>/dev/null || echo 'unreadable'))"
+              rm -f "$body_file"
               return 1
             fi
+            rm -f "$body_file"
             echo "PASS  $method $url  -> $actual (not 500)"
           }
 
@@ -109,11 +141,6 @@ jobs:
           check_status "${PROD}/robots.txt" "GET" "200"
           check_status "${PROD}/api/contact" "GET" "405"
           check_status "${PROD}/non-existent-test-path-xyz123" "GET" "404"
-          # POST /api/contact with intentionally-omitted `full_name` and
-          # `textarea` triggers the route's validation 400 branch (\u2192
-          # {"error":"Missing required fields"}).  The regression signal is
-          # HTTP 500 only (route-handler-runtime crash), per the user's spec:
-          # "200-or-4xx \u2192 500".
           check_not_500 "${PROD}/api/contact" "POST" \
             '{"name":"cron","email":"cron@test.local","message":"nightly cron prod smoke","subject":"smoke","access_key":"placeholder-not-real"}'
 


### PR DESCRIPTION
## ci(prod-smoke): apply post-merge reviewer-flagged hardening

Hardens `.github/workflows/prod-smoke.yml` (the nightly cron workflow
added in [PR #85](https://github.com/batistaDev1113/Portfolio/pull/85))
per the three concrete risks the post-merge code-reviewer flagged.

### Risks addressed

**Risk 1 \u2014 `permissions:` block missing (over-broad token grants).**
Per GHA security guidance for cron workflows that don't touch
GITHUB_TOKEN, the canonical minimal block is `permissions: {}` at the
workflow level. The default token would otherwise grant
contents: read, pull-requests: read/write, etc., and silently activate
those grants if any future maintainer adds a `uses:` action.
**Fix:** added explicit `permissions: {}` at workflow top level.

**Risk 2 \u2014 shared `/tmp/smoke-body` (triage-UX bug on failure).**
Concretely: if `/api/contact` (GET) returns 500 but the prior
`/robots.txt` call wrote a 200 response to `/tmp/smoke-body`, the
`::error` annotation would display robots.txt's body, not the failing
route's. Misleading for the maintainer reading the failure log.
**Fix:** per-route `mktemp` body file, with `rm -f "$body_file"` cleanup
on every exit path (success, status mismatch, 500 detected, curl failure).

**Risk 3 \u2014 no per-curl `--max-time` (unbounded CDN hang).**
If Vercel CDN stalls on one route, curl waits indefinitely until the
5-min job timeout fires mid-assertion. Cron runs nightly, so a transient
CDN hiccup kills the workflow without distinguishing "Vercel is slow"
from "Vercel is down".
**Fix:** `--max-time 30` per curl invocation. 6 routes \u00d7 30 s = 3-min
worst case, fits the 5-min job timeout with 2-min headroom.

### Diff

```
1 file changed, +XX insertions, -YY deletions

.github/workflows/prod-smoke.yml  (modified)
```

### Verification

No source-code changes; local CI gates are unaffected:

| Gate | Expected | Why unaffected |
|---|---|---|
| `npm run lint:check` | exit 0 | ESLint flat-config ignores `*.yml` |
| `npx tsc --noEmit` | exit 0 | tsconfig include patterns exclude YAML |
| `npx jest --watchAll=false` | 14/14 pass | jest doesn't collect YAML |
| `npm run build` | exit 0 | Next.js build doesn't process workflow files |
| `npm audit --omit=dev --audit-level=critical` | exit 0 | workflow YAML has zero dep impact |

### Post-merge

Once this lands on `main`, the cron (`'0 6 * * *'`) begins firing
tonight. First scheduled run will exercise the hardened workflow
end-to-end against `https://yuniorbatista.com`.
