### PR TITLE
chore: gitignore + clean .tmpdraft/ (work-session drafts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,8 @@ next-env.d.ts
 
 # Windows reserved device name artifact
 nul
+
+# Local-only PR-body / commit-msg / issue-body draft directory
+# Used during deep work sessions to template GitHub-side artifacts before
+# committing.  Never to be tracked in git.
+.tmpdraft/


### PR DESCRIPTION
## chore: gitignore + clean .tmpdraft/ (work-session drafts)

Belt-and-suspenders cleanup of the `.tmpdraft/` directory that has
accumulated ~15 markdown drafts (PR-body templates, commit-message
files, issue-body templates) over the recent migration work sessions
that produced:

- [#78](https://github.com/batistaDev1113/Portfolio/pull/78) chore(format): auto-fix prettier CRLF + style issues
- [#79](https://github.com/batistaDev1113/Portfolio/pull/79) chore(tailwind): migrate from v3.3.2 to v4.3.3
- [#80](https://github.com/batistaDev1113/Portfolio/pull/80) chore(git): harden `.gitattributes` with LF/CRLF text rules
- [#83](https://github.com/batistaDev1113/Portfolio/pull/83) chore(deps): drop babel toolchain, let next/jest SWC handle tests
- [#85](https://github.com/batistaDev1113/Portfolio/pull/85) + [#86](https://github.com/batistaDev1113/Portfolio/pull/86) ci(prod-smoke): nightly 6-route curl smoke-test cron

### Changes

**1. `.gitignore` defenses (preventive).** Adds `.tmpdraft/` with a
comment explaining intent \u2014 prevents future contributors from accidentally
`git add`-ing local PR-body/commit-msg drafts they intended to copy-paste
into a `gh pr create` body. Mirrors the established convention already
in place for `.next/`, `node_modules/`, and other local-only artifacts.

**2. `rm -rf .tmpdraft/` (cleanup).** Removes the ~15 stale local drafts
that have accumulated this session. Every draft was either:

- **Consumed** by a merged PR body (e.g., `.tmpdraft/pr-body-drop-babel.md`
  became PR #83's body)
- **Replaced** by a later iteration (e.g., `.tmpdraft/commit-msg-add-contact-route-tests.md`
  was superseded when the actual commit was made via `git commit -F` in
  the basher)
- **Orphan** (close-comment drafts that were posted as-is and never
  iterated on)

### Why both (not just one)

- **Just `.gitignore`**: prevents future contributors from accidentally
  staging drafts, but leaves ~15 files cluttering the repo root locally.
- **Just `rm -rf`**: clean now, but a contributor writing a new draft
  could accidentally `git add .` and reintroduce the problem on a
  future PR.
- **Both**: defense-in-depth \u2014 prevents future leaks + cleans up the
  current mess. One small PR.

### Verification

No source-code changes; 5 local CI gates are unaffected:

| Gate | Expected | Action |
|---|---|---|
| `npm run lint:check` | exit 0 | YAML / .gitignore not linted |
| `npx tsc --noEmit` | exit 0 | tsconfig include patterns exclude non-TS files |
| `npx jest --watchAll=false` | 14/14 pass | jest's collect pattern excludes drafts |
| `npm run build` | exit 0 | Next.js build doesn't process `.gitignore` changes |
| `npm audit --omit=dev --audit-level=critical` | exit 0 | no dep impact whatsoever |

### Post-merge

No further actions needed. `.tmpdraft/` will continue to be a usable
local scratchpad for future work sessions but will be autoignored at
`git add` time so future contributors don't have to think about it.
