### PR TITLE
docs(readme): add Recent migration events callout block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A personal portfolio website built with **Next.js 16** and **React 19**, showcasing projects, skills, and a contact form. Features a modern glassmorphism design with animated backgrounds, dark mode, and smooth Framer Motion transitions.
 
+## Recent migration events
+
+Modern toolchain — **SWC-only** (no Babel dep), **Tailwind v4** (CSS-first,
+no autoprefixer), **LF line endings enforced by `.gitattributes`**.
+
+- [#78](https://github.com/batistaDev1113/Portfolio/pull/78) Prettier CRLF auto-fix across 7 files
+- [#79](https://github.com/batistaDev1113/Portfolio/pull/79) Tailwind v3 → v4 (dropped autoprefixer)
+- [#80](https://github.com/batistaDev1113/Portfolio/pull/80) `.gitattributes` LF gate on `*.js/tsx/json/md`
+- [#83](https://github.com/batistaDev1113/Portfolio/pull/83) Drop Babel devDeps; next/jest SWC compiles tests
+
+Full Path 4 rationale: [ADR 0009](docs/adr/0009-drop-babel-toolchain.md).
+
 ## Tech Stack
 
 | Category | Technology |


### PR DESCRIPTION
## docs(readme): add Recent migration events callout block

Adds a one-screen-orientation block at the top of `README.md`
(between the project-description paragraph and the `## Tech Stack`
section) summarizing the four major toolchain migrations that
produced the repo's current modern state.

### The block

```markdown
## Recent migration events

Modern toolchain \u2014 **SWC-only** (no Babel dep), **Tailwind v4**
(CSS-first, no autoprefixer), **LF line endings enforced by
`.gitattributes`**.

- [#78](...) Prettier CRLF auto-fix across 7 files
- [#79](...) Tailwind v3 \u2192 v4 (dropped autoprefixer)
- [#80](...) `.gitattributes` LF gate on `*.js/tsx/json/md`
- [#83](...) Drop Babel devDeps; next/jest SWC compiles tests

Full Path 4 rationale: [ADR 0009](docs/adr/0009-drop-babel-toolchain.md).
```

### Why

New contributors reading the codebase cold today see:

- `package.json` says `next@^16`, `react@^19`, `tailwindcss@^4`
- No `@babel/preset-*`, no `babel-jest` in `devDependencies`
- `.gitattributes` enforces LF line endings (Windows-friendly)
- Sentry, next-themes, framer-motion, etc. all current

Without context, they might:

- Wonder why there's no `.babelrc` \u2192 search git log \u2192 discover the
  babel-drop rationale across 4+ PRs (Path 4)
- Ask why Tailwind looks CSS-first instead of config-file-driven \u2192
  find PR #79
- Ask why `.gitattributes` exists \u2192 find PR #80

This callout front-loads that context at the top of `README.md`, so
a cold-read contributor can answer those questions in 10 seconds
instead of 10 minutes of git archaeology.

### Cross-link to ADR 0009

The block ends with a pointer to the recently-added
[`docs/adr/0009-drop-babel-toolchain.md`](docs/adr/0009-drop-babel-toolchain.md)
ADR for the full Path 4 rationale \u2014 making the README + ADR pair
a complete orientation surface.

### Diff

```
1 file changed, +13 insertions, 0 deletions
README.md
```

### Verification

| Gate | Expected result |
|---|---|
| `npx prettier --check README.md` | exit 0 (proseWrap: preserve, lines fit printWidth=80) |
| `npm run lint:check` | exit 0 (eslint flat-config ignores `*.md`) |
| `npx tsc --noEmit` | exit 0 (tsconfig include patterns exclude non-TS) |
| `npx jest --watchAll=false` | 14/14 pass (jest's collect pattern excludes docs + root *.md) |
| `npm run build` | exit 0 (Next.js build doesn't process `README.md`) |
| `npm audit --omit=dev --audit-level=critical` | exit 0 (no dep impact) |
