### PR TITLE
chore(docs): add Issue #95 self-tracking cross-ref to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,3 +52,44 @@ specific count in a downstream advisory.
 When staging a merge, run `npm audit --omit=dev --audit-level=critical`
 locally and surface `failure: 0` explicitly rather than trusting the
 GitHub-side rollup, which can briefly flicker `FAIL` while status checks rerun.
+
+## Upstream-unblock watcher pattern
+
+When polling upstream packages for an installed-deps unlock (e.g., a peer-bump
+that gates `.npmrc legacy-peer-deps=true` reversibility — see PR #96), follow
+the canonical template documented in the body of
+[Issue #95](https://github.com/batistaDev1113/Portfolio/issues/95)
+("Track upstream unblock: …"). That issue's body now contains a complete
+agentic template — do **not** re-derive the structure ad hoc. Required
+components (all five expected):
+
+- **TL;DR** — a single Markdown blockquote at the top stating the close-
+  trigger (Constraint `(a)` OR Constraint `(b)`).
+- **Monitoring schedule** — concrete bash probes against the relevant
+  `npm view … peerDependencies` / `… dependencies.<pkg>` endpoints, run
+  on a weekly cadence. **Note**: `peerDependencies` lists a package's
+  demands-from-its-consumer; for transitive-bump checks, read the
+  consumer's *dependencies* first (range), then resolve + query the
+  transitive peer's `peerDependencies` (Constraint (b) does this).
+- **Reversal-criteria checklist** — bullets naming the two close-trigger
+  conditions the weekly poll watches for, plus the `(a)`/`(b)`
+  verification commands.
+- **Branch-first reversal procedure** — opens a feature branch off
+  `main` (per the AGENTS.md canonical safe pattern) as the **first**
+  step; the `.npmrc ` / equivalent reversible-flag change + the 5-gate
+  verification (lint / tsc / jest / build / audit) + re-install without
+  the flag come **after** the branch is open. Sanity-check the staged
+  diff before pushing.
+- **Evidence-chain capture** — when a close-trigger observation is
+  recorded, capture `ISO date` + the verbatim `npm view` stdout that
+  triggered the close call + `git rev-parse origin/main` at observation
+  time, in a close-comment on the tracking issue. Audit-trail for the
+  close decision; protects against retracted npm publishes / transient
+  peer-field typos.
+
+Issue #95's body and `.github/workflows/weekly-jsx-a11y-watch.yml`
+(PR #99 — fires on cron `'30 0 * * 1'` per Issue #95's Monitoring
+schedule, with `workflow_dispatch` available for ad-hoc manual
+diagnostic runs) are the working examples of this pattern — clone
+their structure for any future upstream-watcher issue rather than
+re-deriving.


### PR DESCRIPTION
## What

Adds a `## Upstream-unblock watcher pattern` section to `AGENTS.md` cross-referencing [Issue #95](https://github.com/batistaDev1113/Portfolio/issues/95) as the canonical upstream-watcher-pattern runbook template.

## Why

Issue #95's body evolved through several cleanup turns into a runbook-quality template (TL;DR + Monitoring schedule + Reversal-criteria checklist + Branch-first reversal procedure + ISO-date/git-rev-parse evidence-chain capture). Future agent runs polling upstream-package unlocks would otherwise re-derive that structure ad-hoc. Linking from `AGENTS.md` (the agent-facing runbook at the repo root) makes the template discoverable.

## Diff

~22-line insertion in `AGENTS.md` (new short section, third section after gh-CLI and Audit-gate). No code changes.

## Reference

The section cross-refs `.github/workflows/weekly-jsx-a11y-watch.yml` (PR #99) as the working example of this pattern.
