### PR TITLE
chore(docs): add Tool quirks cross-ref to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- .github/PULL_REQUEST_TEMPLATE.md -->
+<!-- Fallback for human contributors opening PRs via the GitHub web UI.
+     Agentic/automated runs should still use `gh pr create --body-file <path>`
+     per the canonical pattern documented in AGENTS.md
+     (`## gh CLI: do not use --yes on gh pr merge` section). -->
+
+## Summary
+
+<!-- 1-3 sentences describing what the change does and why. -->
+
+## Type of change
+
+<!-- Pick: bug fix / new feature / chore / refactor / docs / test -->
+
+## Test plan
+
+<!-- Which gates were run before opening this PR?
+     (lint / tsc / jest / build / audit / manual smoke test) -->
+
+## Reviewer checklist
+
+<!-- Reminders for the reviewer -->
+
+- If your PR adds or modifies `AGENTS.md`, review the new
+  `## Tool quirks` section for any newly-discovered tool-shape
+  failures; cross-link forward references inside the section body.


### PR DESCRIPTION
## What

Adds `.github/PULL_REQUEST_TEMPLATE.md` — a GitHub-side fallback
PR template that the web UI auto-applies when human contributors
open PRs without specifying a body. Includes a single bullet under
the Reviewer checklist section pointing contributors at the
AGENTS.md `## Tool quirks` section.

## Why

AGENTS.md ships a `## Tool quirks: basher shape failure` section
(added in PR #102) that documents a recurring failure-pattern
surface. Future PRs that touch AGENTS.md should self-police: when
adding new tool-shape failures, the section’s cross-references and
Working examples sub-bullets need to be updated. The PR template
makes this an explicit pre-submission reminder rather than a
reviewer-caught post-merge fixup.

## Agentic vs human-UI split

Agentic runs continue to bypass the template via
`gh pr create --body-file <path>` per the AGENTS.md canonical
pattern (`## gh CLI: do not use --yes on gh pr merge`
section). The template’s HTML-comment header documents this split
explicitly. Only web-UI human contributors hit the fallback.

## Diff

- 1 file added, ~26 lines net
- `.github/PULL_REQUEST_TEMPLATE.md` previously did not exist;
  this PR creates it from scratch.

## Cross-reference line (verbatim per user prompt)

> - If your PR adds or modifies `AGENTS.md`, review the new
>   `## Tool quirks` section for any newly-discovered tool-shape
>   failures; cross-link forward references inside the section
>   body.

The loose `## Tool quirks` reference (no `: `basher` shape failure`
qualifier) is intentional and forward-compatible with future
`## Tool quirks:` sub-sections.