### PR TITLE
chore(ci): fix weekly-jsx-a11y-watch probe-b EINVALIDTAGNAME failure

### DIFF
--- a/.github/workflows/weekly-jsx-a11y-watch.yml
+++ b/.github/workflows/weekly-jsx-a11y-watch.yml
@@ -103,8 +103,24 @@ jobs:
           # instead of `6.10.2` (e.g., a future patch publish), the
           # audit trail records exactly what was queried, not just the
           # range as-of some earlier observation.
+          #
+          # Range resolution: `npm view <pkg>@<semi-range> version`
+          # returns a multi-line list of all matching versions
+          # (e.g., for `^6.10.0` it lists 6.10.0, 6.10.1, 6.10.2).
+          # Piping through `jq -r` over `--json` normalises: an
+          # array-of-versions comes back as a JSON array (pick the LAST
+          # entry, which npm emits in ascending semver order so it is
+          # the highest matching version); a single-version query
+          # returns a JSON string and passes through unchanged. This
+          # avoids the previous `RESOLVED` containing multi-line +
+          # whitespace content, which the downstream
+          # `npm view "eslint-plugin-jsx-a11y@${RESOLVED}" peer` was
+          # rejecting with EINVALIDTAGNAME and aborting the entire
+          # probe-b step via `set -euo pipefail` (Run Summary and
+          # Comment-on-#95 steps then got skipped due to GitHub Actions
+          # default next-step-on-failure behaviour).
           JSX_A11Y_RANGE=$(npm view eslint-config-next@latest dependencies.eslint-plugin-jsx-a11y)
-          RESOLVED=$(npm view "eslint-plugin-jsx-a11y@${JSX_A11Y_RANGE}" version)
+          RESOLVED=$(npm view "eslint-plugin-jsx-a11y@${JSX_A11Y_RANGE}" version --json | jq -r 'if type=="array" then .[-1] else . end')
           PEER=$(npm view "eslint-plugin-jsx-a11y@${RESOLVED}" peerDependencies.eslint)
           echo "eslint-config-next transitively pins eslint-plugin-jsx-a11y@${JSX_A11Y_RANGE}; resolved to ${RESOLVED}"
           echo "transitive peerDependency.eslint (next's jsx-a11y): ${PEER}"


### PR DESCRIPTION
## What

Fixes a probe-b failure in `.github/workflows/weekly-jsx-a11y-watch.yml`
that was preventing Constraint (b) from ever reaching the
comment-on-Issue-#95 step. The bug surfaced as `npm error code
EINVALTAGNAME` on Ubuntu runners.

## Why

Issue #95's auto-close depends on this watcher firing reliably
on both the manual `workflow_dispatch` path and the weekly cron
`30 0 * * 1`. Run #30562415294 (pre-fix) showed the bug:

```
[Constraint (a) ... latest peer.eslint]               conclusion=success
[Constraint (b) ... transitive jsx-a11y peer.eslint] conclusion=failure
[Run summary]                                         conclusion=skipped
[Comment on Issue]                                    conclusion=skipped
```

Two compounding failure modes:

1. **Probe-b self-failure.** `npm view "eslint-plugin-jsx-a11y@^6.10.0"
   version` returns a multi-line list of all matching versions
   (npm range resolution expands to siblings). The previous probe-b
   `run` block piped that multi-line output into the next
   `npm view @${RESOLVED} peer` call where `RESOLVED` had been
   replaced with raw `name@version` lines + whitespace. npm
   rejected with EINVALIDTAGNAME, `set -euo pipefail` exited
   non-zero, and the entire probe-b step failed.

2. **NEXT-STEP-ON-FAILURE masking probe-a.** Worse than the
   visible probe-b failure, GH Actions' default semantics skip
   all subsequent steps on the FIRST failed step in a job,
   regardless of the `if:` condition. So if Constraint (a)
   legitimately triggers (`jsx-a11y@7+` ships with `peer.eslint`
   accepting `^10`), probe-b's structural bug would prevent the
   auto-close-comment from ever being posted. The watcher was
   broken in the close-trigger direction too.

## The fix

Switch probe-b's `RESOLVED=` query to npm-view's `--json` output +
`jq -r` to normalise range queries into single-string output:

```bash
RESOLVED=$(npm view "eslint-plugin-jsx-a11y@${JSX_A11Y_RANGE}" version --json | jq -r 'if type=="array" then .[-1] else . end')
```

Behaviour:

- Array of versions (range query, e.g., `^6.10.0` returns
  `[6.10.0, 6.10.1, 6.10.2]`): `jq -r` picks `.[-1]` (last
  element, which npm emits in ascending semver order so it is the
  highest matching version).
- Single string (exact-version query, e.g., `dist-tags.latest`
  returns `"6.10.2"`): `jq -r` returns the string itself,
  unchanged.

`jq` is pre-installed on `ubuntu-latest` GH Actions runners; `--json`
ships with npm 7+ (this repo uses npm 16+). Inline comment block
in the workflow now documents the rationale so future maintainers
do not revert.

## Regression risk

- `ubuntu-latest` runner ships `jq` pre-installed (stable for
  years).
- npm 7+ `--json` is uncontroversial (shipped 2020).
- Probe-a's pattern (`@latest`, not a range) is unaffected: it
  returns single-string output and the bash assignment captures
  it cleanly without JSON parsing. Probe-a is unchanged.
- The new inline comment block is exhaustive; future maintainers
  will not accidentally revert to the pre-fix form without seeing
  the EINVALIDTAGNAME trap warning.

## Verification

After merge:

- `gh workflow run weekly-jsx-a11y-watch.yml --ref main` should
  report probe-a=success/satisfied=false, probe-b=success/
  satisfied=false, Run summary=success, Comment-on-#95=skipped
  (correct silence), job conclusion=SUCCESS.
- Issue #95 should have comment count remain at 0 (no
  false-positive comment posted).

## Audit trail

Evidence chain captured (per AGENTS.md upstream-unblock-watcher
pattern):

- Pre-fix: gh run id `30562415294`, conclusion=`failure`.
- Local pre-flight: `npm view eslint-plugin-jsx-a11y@^6.10.0 version`
  returns the multi-version list shape that triggered
  EINVALIDTAGNAME.
- Local pre-flight: `npm view eslint-plugin-jsx-a11y@^6.10.0
  peerDependencies.eslint` returns the same multi-version list
  shape (one peer line per matching version) - confirms Option (A)
  "skip RESOLVED step entirely" would also need fixing.
- Post-fix verification: re-run workflow via workflow_dispatch
  and observe probe-b success + Run summary "Constraint (b)
  satisfied: false" + job conclusion success.
