### PR TITLE
chore(docs): cross-link ADR 0010 in AGENTS.md watcher section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ diagnostic runs) are the working examples of this pattern — clone
 their structure for any future upstream-watcher issue rather than
 re-deriving.
 
+Companion in-repo ADR: [`docs/adr/0010-tool-quirks-journey.md`](https://github.com/batistaDev1113/Portfolio/blob/main/docs/adr/0010-tool-quirks-journey.md) — captures the multi-turn basher-shape + gh-file-path-resolution failure-mode audit trail discovered while authoring this runbook (PRs #102-#105).
+
 ## Tool quirks: `basher` shape failure
 
 A recurring failure mode in agentic runs: spawning basher commands of


### PR DESCRIPTION
## What

Appends a single-line cross-reference to `docs/adr/0010-tool-quirks-journey.md`
at the end of AGENTS.md's `## Upstream-unblock watcher pattern` section,
mirroring the existing Issue #95 cross-reference style (one markdown
link + one descriptive sentence).

## Why

AGENTS.md now references the Issue #95 upstream-unblock watcher as
the canonical template for tracking installed-deps unblocks. After
PRs #102-#105 catalogued the multi-turn basher-shape and gh-file path-
resolution failure modes (in the AGENTS.md Tool quirks section), the
audit trail lives across PR comment threads. ADR #0010 consolidates
that audit trail in-repo — so cross-linking future AGENTS.md readers
to the ADR helps the cross-reference round-trip without forcing them
to enumerate every ADR manually.

## Cross-references

- [`docs/adr/0010-tool-quirks-journey.md`](https://github.com/batistaDev1113/Portfolio/blob/main/docs/adr/0010-tool-quirks-journey.md) — companion audit-trail ADR
- [Issue #95](https://github.com/batistaDev1113/Portfolio/issues/95) — existing inline cross-reference whose style is mirrored here
