### PR TITLE
test(e2e): add Hero bio+title regression net via Playwright

### DIFF
--- a/.github/workflows/e2e-hero.yml
+++ b/.github/workflows/e2e-hero.yml
@@ -1,0 +1,101 @@
+# Playwright integration test for the Hero bio + title regression net.
+#
+# Captures the 3 manual visual regressions (bio 2-paragraph visibility,
+# title-text match, pageerror capture) that were verified against the Vercel
+# preview-deploy URL during PR #118's merge via browser-use.  After this
+# workflow lands, those manual verifications become a CI gate that blocks
+# any future revert without human-in-the-loop intervention.
+#
+# Triggers:
+#   - push to main: catches Hero content drift on the main branch
+#   - pull_request: blocks PR merges that regress the bio+title content
+#   - workflow_dispatch: manual ad-hoc run from GitHub UI / CLI / API
+#
+# Hardening (mirrors .github/workflows/prod-smoke.yml's pattern):
+#   - permissions: {} (zero GITHUB_TOKEN grants, future-proof against
+#     accidental over-broad permission inheritance if a future step is
+#     added.  Default github.token perms over-grant silently.)
+#   - timeout-minutes: 10 (Playwright + chromium install + Next.js prod
+#     build can be slow on cold cache; 5-min job timeout would flake.)
+#   - explicit build split (build failures vs test failures are reported
+#     SEPARATELY, so the audit-trail pinpoints "is the build broken" vs
+#     "is the regression net broken" without ambiguity).
+#   - browser-binary cache via actions/cache@v4 keyed on package-lock.json
+#     (~400MB chromium download per cold run == hits the GHA rate limit;
+#     caching keyed on lockfile makes follow-up runs restoration-only.)
+#   - artifact upload on failure (Playwright trace + HTML report are
+#     uploaded so a CI failure can be debugged from the GitHub UI without
+#     needing a local re-run.)
+#
+# Failure semantics:
+#   - Build step exit non-zero: workflow aborts before the playwright
+#     step runs.  Audit-trail: "build broke, check the build" not
+#     "playwright test broke".
+#   - Playwright step exit non-zero: workflow fails, the playwright-report
+#     + test-results/ artifacts are uploaded, the PR is blocked.
+#
+# Reference sibling workflows (.github/workflows/):
+#   - dependency-review.yml — minimal single-step pattern
+#   - prod-smoke.yml — 5-minute cron + dispatch + zero-perms hardening
+#   - security-audit.yml — cron + push + PR + dispatch trigger pattern
+
+name: e2e-hero
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+# Explicit zero-permissions block, mirroring prod-smoke.yml (PR #85).
+# Default would over-grant (contents: read, pull-requests: read/write,
+# etc.) and silently activate if any future step adds a `uses:` action.
+permissions: {}
+
+jobs:
+  test:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    env:
+      CI: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.node-version'
+          cache: 'npm'
+
+      - name: Install dependencies (legacy-peer-deps via .npmrc from PR #96)
+        run: npm ci
+
+      - name: Cache Playwright browser binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Build production app (fail-fast on build errors)
+        run: npm run build
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ nul
 # Used during deep work sessions to template GitHub-side artifacts before
 # committing.  Never to be tracked in git.
 .tmpdraft/
+
+# Playwright test artifacts (regenerable on each test run, not source)
+# The HTML report, traces, screenshots, and videos belong here.
+# Tracked test code lives in __tests__/e2e/ + playwright.config.js.
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,11 @@ PR #118 (`feat(content): update Hero bio + title to Senior Frontend Engineer`) s
 
 
 
+## Tool quirks: Playwright `webServer` requires prior `npm run build`
+
+A small follow-up to the `pretest:e2e` lifecycle-hook decision (CR-NIT-2 from the post-NIT-3rd-pass review of `chore/playwright-hero-regression-test`): `npm run test:e2e` does **NOT** auto-build the production app. `.github/workflows/e2e-hero.yml`'s explicit `name: Build production app` step sequences `npm run build` immediately before `npm run test:e2e`, so CI is unaffected. But local shells (developer machines, agent basher invocations, ad-hoc `npm run test:e2e:ui` debugging) MUST run `npm run build && npm run test:e2e` manually for the playwright `webServer` to find a `.next/` build directory. The previously-attempted `pretest:e2e` npm hook (`npm run build` before every `test:e2e` invocation) was removed because it would have caused a CI double-build (workflow builds, then pretest hook re-builds). **Operational discipline:** always prefix local `npm run test:e2e` / `npm run test:e2e:ui` invocations with `npm run build` to ensure the playwright webServer starts cleanly. **Symptom of forgetting:** playwright will fail loudly with `url 'http://localhost:3000' didn't respond` within the `webServer.timeout: 120_000` window (set in `playwright.config.js`), surfacing the build-missing failure as a playwright timeout (NOT a confusing 'why did next dev fail' message). The `playwright.config.js` header comment also documents this sequence, but this AGENTS.md entry is the canonical reminder for agentic runs.
+
+
 ## Audit tooling snapshots
 
 `scripts/audit-tally.mjs` and `scripts/audit-leaf.mjs` (introduced by the `chore/audit-scripts` PR for the Issue #114 audit-tracker turn) reconcile `npm audit --json`'s `meta.vulnerabilities.high` (propagation-path count through the dep graph, includes multi-path chains aggregated) against the **distinct leaf-cert GHSA count** (the actual upstream fixes needed). Re-run on any new audit snapshot:

--- a/__tests__/e2e/hero.spec.js
+++ b/__tests__/e2e/hero.spec.js
@@ -1,0 +1,124 @@
+// __tests__/e2e/hero.spec.js
+// Playwright integration regression net for Hero bio + title content.
+//
+// Captures the 3 visual regressions verified manually during PR #118
+// (`feat(content): update Hero bio + title to Senior Frontend Engineer`)
+// via browser-use against the Vercel preview-deploy URL.  After this PR
+// lands, those manual checks are automated — a future bio+title revert
+// surfaces as a CI failure on this spec without needing human-in-the-loop
+// verification.
+//
+// Three primary assertions:
+//   1. bio 2-paragraph visibility — `whitespace-pre-line` + literal `\n\n`
+//      in the template literal must render as a visible blank line AND both
+//      paragraph starts ("Hi, I'm Yunior—a product-minded" +
+//      "I care about creating accessible") MUST be present in textContent.
+//   2. title-text content match — visible title MUST contain
+//      "Senior Frontend Engineer" AND MUST NOT contain
+//      "Senior Frontend Developer" anywhere INSIDE the hero section.
+//   3. pageerror / console.error capture — zero uncaught exceptions OR
+//      console.error messages during the full page lifecycle (catches
+//      hydration mismatches + Next.js dev/prod drifts + Sentry tunnelRoute
+//      /monitoring failures + 4xx/5xx network errors on prerender payloads).
+//
+// Plus belt-and-suspenders sanity:
+//   - hero-section testid visible
+//   - profile image visible with the correct alt text
+//   - resume link href unchanged (`/Yunior-Batista-Resume.pdf`)
+//
+// Selectors use stable testid anchors (data-testid="hero-title" +
+// data-testid="hero-bio" + data-testid="hero-section" added to
+// components/Hero.tsx) instead of Tailwind class dependencies, so a future
+// Tailwind class rename or framer-motion de-tour doesn't silently break
+// the regression net.
+//
+// ESM `import` syntax to match the existing __tests__/*.test.js jest specs in
+// this repo (e.g., __tests__/Hero.test.js / __tests__/Home.test.js).  This
+// file is excluded from eslint via `eslint.config.js`'s
+// ignores['__tests__/e2e/'] entry because @playwright/test globals
+// (`test` / `expect`) are not registered by eslint-config-next.
+
+import { expect, test } from '@playwright/test';
+
+test.describe('Hero section: bio + title regression net', () => {
+  test('renders correctly with zero console errors', async ({ page }) => {
+    // ---- 3. pageerror / console-error regression net ----
+    // Capture every error during the entire page lifecycle.
+    const errors = [];
+    page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        errors.push(`console.error: ${msg.text()}`);
+      }
+    });
+
+    await page.goto('/');
+
+    // Scope every assertion to the hero section so that other-page
+    // content (footer / projects / contact form / future additions)
+    // cannot spuriously break the regression net.
+    const heroSection = page.locator("[data-testid='hero-section']");
+    await expect(heroSection).toBeVisible();
+
+    // ---- 2. title-text content match ----
+    // Visible title anchored to data-testid="hero-title" (added to
+    // components/Hero.tsx alongside the existing data-testid on the
+    // outer section) — survives Tailwind class renames + framer-motion
+    // wrapper changes.
+    const title = heroSection.locator("[data-testid='hero-title']");
+    await expect(title).toBeVisible();
+    await expect(title).toHaveText(/Senior Frontend Engineer/i);
+
+    // Negative assertion: the pre-PR-#118 title MUST NOT appear in the
+    // title element itself.  Scoped to `title` (not the whole heroSection,
+    // not the whole page) so a future bio paragraph legitimately
+    // referencing "Senior Frontend Developer" as historical career
+    // context (e.g., "Previously: Senior Frontend Developer at X co.")
+    // can't spuriously break this net.  Assertion target = the title
+    // element's own text content.
+    await expect(title).not.toHaveText(/Senior Frontend Developer/i);
+
+    // ---- 1. bio 2-paragraph visibility ----
+    // Bio `<p>` anchored to data-testid="hero-bio" (added to
+    // components/Hero.tsx).  Framer Motion stagger has a delay: 2
+    // (seconds) on the bio wrapper, so we wait up to 5s for it to be
+    // visible before reading its textContent.
+    const bio = heroSection.locator("[data-testid='hero-bio']");
+    await expect(bio).toBeVisible({ timeout: 5 * 1000 });
+
+    const text = (await bio.textContent()) ?? '';
+
+    // Both paragraph starts MUST be present, proving the bio shipped the
+    // 2-paragraph narrative (not a 1-paragraph revert).  Uses the literal
+    // em-dash `—` (the actual character in components/Hero.tsx) rather
+    // than a hyphen/en-dash/em-dash character class — so a future
+    // dash-substitution typo in production copy breaks the spec loudly
+    // instead of silently passing.
+    expect(text).toMatch(/Hi, I'm Yunior\u2014a product-minded/);
+    expect(text).toMatch(/I care about creating accessible/);
+
+    // The bio must still apply the whitespace-pre-line rule that makes the
+    // literal "\n\n" render as a visible blank line between paragraphs.
+    // (Computed style check catches CSS class rename / Tailwind v4 / dark
+    // mode overrides that would silently strip the rule.)
+    const computedWhiteSpace = await bio.evaluate(
+      (el) => window.getComputedStyle(el).whiteSpace
+    );
+    expect(computedWhiteSpace).toBe('pre-line');
+
+    // ---- Layout sanity (belt-and-suspenders) ----
+    const profileImg = heroSection.getByAltText(
+      'Yunior Batista - Senior Frontend Engineer'
+    );
+    await expect(profileImg).toBeVisible();
+
+    const resumeLink = heroSection.getByRole('link', { name: 'View Resume' });
+    await expect(resumeLink).toHaveAttribute(
+      'href',
+      '/Yunior-Batista-Resume.pdf'
+    );
+
+    // ---- 3. assert zero captured errors ----
+    expect(errors).toEqual([]);
+  });
+});

--- a/__tests__/e2e/hero.spec.js
+++ b/__tests__/e2e/hero.spec.js
@@ -8,6 +8,10 @@
 // surfaces as a CI failure on this spec without needing human-in-the-loop
 // verification.
 //
+// Filter in this spec: ignores known-environmental console.error noise from
+// `@vercel/analytics` injecting `/_vercel/insights/script.js`. See the
+// page.on('console', ...) listener below for the rationale + future-extension guide.
+//
 // Three primary assertions:
 //   1. bio 2-paragraph visibility — `whitespace-pre-line` + literal `\n\n`
 //      in the template literal must render as a visible blank line AND both
@@ -18,8 +22,20 @@
 //      "Senior Frontend Developer" anywhere INSIDE the hero section.
 //   3. pageerror / console.error capture — zero uncaught exceptions OR
 //      console.error messages during the full page lifecycle (catches
-//      hydration mismatches + Next.js dev/prod drifts + Sentry tunnelRoute
-//      /monitoring failures + 4xx/5xx network errors on prerender payloads).
+//      hydration mismatches + Next.js dev/prod drifts + 4xx/5xx network
+//      errors on prerender payloads).
+//      Note: known-environmental noise from `@vercel/analytics` is
+//      filtered at the console-error listener below (the only error
+//      observed on the first CI run was `/_vercel/insights/script.js`
+//      404, see `page.on('console')`).  Vercel's edge rewrites that URL
+//      only on Vercel deploys; on `npm run start` (local + GitHub Actions
+//      runners) it 404s with text/html MIME type from Next.js's 404
+//      fallback.  This is documented behavior of @vercel/analytics, NOT
+//      a regression in our code.  Filter at the listener -- do NOT
+//      disable the analytics package globally (that would silently
+//      regress the prod observability surface).  Future contributors
+//      adding new known-environmental noise (e.g., `/_vercel/speed-insights/*`)
+//      should ADD to the filter, not remove it.
 //
 // Plus belt-and-suspenders sanity:
 //   - hero-section testid visible
@@ -48,7 +64,19 @@ test.describe('Hero section: bio + title regression net', () => {
     page.on('pageerror', (err) => errors.push(`pageerror: ${err.message}`));
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
-        errors.push(`console.error: ${msg.text()}`);
+        const text = msg.text();
+        // Filter known-environmental noise from `@vercel/analytics`:
+        // /_vercel/insights/script.js is rewritten by Vercel's edge to a
+        // real CDN script in production deploys, but 404s (text/html MIME
+        // type) on `npm run start` against any non-Vercel host = our local
+        // + CI setup. Both `Failed to load resource` (Chrome resource
+        // loader) AND `Refused to execute script ... MIME type` (Chrome
+        // script loader) errors include `/_vercel/insights` as a substring,
+        // so a single filter is sufficient. Real regressions on a future
+        // PROD build (where /_vercel/insights is rewritten) would be
+        // unaffected.
+        if (text.includes('/_vercel/insights')) return;
+        errors.push(`console.error: ${text}`);
       }
     });
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -70,7 +70,10 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={{ delay: 1.5, ease: 'easeInOut' }}
               className='my-5 text-center w-full'
             >
-              <span className='text-transparent bg-gradient-to-r from-blue-200 via-purple-200 to-indigo-200 bg-clip-text text-2xl md:text-3xl font-semibold drop-shadow-lg'>
+              <span
+                data-testid='hero-title'
+                className='text-transparent bg-gradient-to-r from-blue-200 via-purple-200 to-indigo-200 bg-clip-text text-2xl md:text-3xl font-semibold drop-shadow-lg'
+              >
                 Senior Frontend Engineer
               </span>
             </m.div>
@@ -80,7 +83,10 @@ I care about creating accessible, high-performance interfaces that are not only 
               viewport={{ once: true }}
               transition={{ delay: 2, ease: 'easeInOut' }}
             >
-              <p className='text-base text-white/85 max-w-lg text-center leading-6 drop-shadow-sm backdrop-blur-sm bg-white/5 rounded-lg p-4 border border-white/10 whitespace-pre-line'>
+              <p
+                data-testid='hero-bio'
+                className='text-base text-white/85 max-w-lg text-center leading-6 drop-shadow-sm backdrop-blur-sm bg-white/5 rounded-lg p-4 border border-white/10 whitespace-pre-line'
+              >
                 {HERO_ABOUT_TEXT}
               </p>
             </m.div>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,7 @@ module.exports = [
       'coverage/',
       '.vercel/',
       '__tests__/coverage/',
+      '__tests__/e2e/',
       '.jest/',
     ],
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,15 @@ const config = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
 
   testEnvironment: 'jest-environment-jsdom',
+
+  // Exclude Playwright integration tests from jest's default testMatch.
+  // Jest's default '**/__tests__/**/*.{js,ts}' glob would otherwise pick
+  // up the .spec.js files in __tests__/e2e/ and fail to load them -- those
+  // are owned by the `playwright test` runner, not jest.  Local + CI both
+  // confirmed this exclusion is needed: jest before the exclusion tried
+  // to import @playwright/test as a JS module and the test suite crashed
+  // with "SyntaxError: Cannot use import statement outside a module".
+  testPathIgnorePatterns: ['/node_modules/', '/__tests__/e2e/'],
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "tailwindcss": "^4.3.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/forms": "^0.5.11",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.1.4",
@@ -2557,6 +2558,22 @@
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -10308,6 +10325,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "hygiene:branches": "node scripts/check-branch-clean.mjs",
     "lint": "eslint . --fix",
     "lint:check": "eslint .",
-    "test": "jest --watch"
+    "test": "jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@sentry/nextjs": "^10.69.0",
@@ -39,6 +41,7 @@
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/forms": "^0.5.11",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.1.4",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,76 @@
+// playwright.config.js
+// Configuration for the Hero bio+title visual regression suite (the regression
+// net for the Hero bio+title content shipped in PR #118 — the manual browser-use
+// verifications are now automated here, so a future bio+title revert is caught
+// by CI without needing human-in-the-loop verification).
+//
+// See __tests__/e2e/hero.spec.js for the actual assertions.
+//
+// Tradeoffs (per Thinker-with-files verdict on the non-trivial Playwright
+// integration architecture fork):
+//   - chromium-only project: smallest CI install footprint (~400MB saved vs
+//     3-way matrix), fastest cold-cache restore via actions/cache@v4
+//     (.github/workflows/e2e-hero.yml).
+//   - webServer = `npm run start` on http://localhost:3000 (port 3000 is
+//     next start's default; baseURL avoids bundling it into every locator).
+//     CI workflow explicitly sequences `npm ci` -> `playwright install`
+//     -> `npm run build` -> `npm run test:e2e` so a build failure aborts
+//     before the playwright step runs (clear audit-trail separation).
+//   - retries: process.env.CI ? 2 : 0 — tolerates one transient Next.js
+//     hydration race or Vercel CDN 308 redirect flicker in CI without
+//     spuriously failing the build.
+//   - workers=1 in CI: avatars + 4 staggered Framer Motion transitions
+//     (delays 0.5s/1s/1.5s/2s in components/Hero.tsx) need stable per-page
+//     timing; parallel workers can race the timing-sensitive assertions.
+//   - timeout 30s + expect 5s: enough for the 2s Framer stagger delay +
+//     SSR'd page (~39 KB content) + any CSP prerender overhead.
+//   - headless: true, trace: 'on-first-retry': collects full Playwright
+//     traces (DOM, network, screenshot timeline) on the rare failure for
+//     downstream debugging, costs ~5MB on the rare failing run.
+//
+// Pins: kept CommonJS to match next.config.js / jest.config.js / postcss.config.js
+// in this repo. Project's package.json does NOT declare `"type": "module"`.
+
+const { defineConfig, devices } = require('@playwright/test');
+
+module.exports = defineConfig({
+  // Honor user's explicit path requirement ("adds an automated Playwright
+  // integration test to __tests__/").
+  testDir: './__tests__/e2e',
+  // Match `.spec.js` suffix only so jest's `*.test.js` files are NOT
+  // picked up by the Playwright runner (jest already owns those).
+  testMatch: '**/*.spec.js',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  timeout: 30 * 1000,
+  expect: { timeout: 5 * 1000 },
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    headless: true,
+    viewport: { width: 1280, height: 720 },
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  // webServer assumes the caller (workflow step or local shell) has already
+  // run `npm run build`.  CI workflow: "Build production app" step runs
+  // immediately before "Run Playwright tests" so the artifact is fresh.
+  // Local: `npm run build && npm run test:e2e` in sequence.
+  webServer: {
+    command: 'npm run start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+});


### PR DESCRIPTION
## What

2 commits on branch `chore/playwright-hero-regression-test`: initial 4-new + 5-modified (commit 4388b42) + CI-noise-filter fixup (commit 8c4d55f).

### Commit 1: `test(e2e): add Hero bio+title regression net via Playwright` (4388b42)

4 new files + 5 modifications + 1 devDep add for a Playwright integration regression net that catches any future `<Hero />` bio+title revert in CI without requiring human-in-the-loop browser-use verification.

#### New files (4)

- **`playwright.config.js`** (CommonJS, root-level): Official `playwright/test` runner config. `testDir: ./__tests__/e2e`, `testMatch: **/*.spec.js`, chromium-only project.
- **`__tests__/e2e/hero.spec.js`**: Single Playwright spec asserting 3 visual regressions: bio 2-paragraph visibility, title-text content match, zero pageerror + console.error.
- **`.github/workflows/e2e-hero.yml`**: New CI workflow with zero permissions, 10-min timeout, build split, browser-binary cache via actions/cache@v4.
- **Documentation addition to `AGENTS.md`**: New Tool quirks entry documenting the local-build-first Playwright sequence (since the previously-attempted `pretest:e2e` npm hook was removed to avoid CI double-build).

#### Modified files (5)

- **`components/Hero.tsx`** -- Added `data-testid="hero-title"` + `data-testid="hero-bio"` as stable test anchors.
- **`jest.config.js`** -- Added `testPathIgnorePatterns` to exclude playwright spec files from jest (caused: 1 failed suite on first run; resolved via the exclusion).
- **`eslint.config.js`** -- Added `__tests__/e2e/` to ignores (eslint-config-next doesnt register @playwright/test globals).
- **`package.json`** -- Added `test:e2e + test:e2e:ui` scripts. No `pretest:e2e` hook (would double-build in CI per CR-NIT-2).
- **`.gitignore`** -- Added Playwright artifact dirs.

#### DevDep

`@playwright/test` -- 3 packages added (devDep only; production deps unchanged).

### Commit 2: `fix(test): filter /_vercel/insights environmental noise from spec` (8c4d55f)

Closes the e2e-hero CI failure observed on PR #120s first run. The new workflow ran for the first time and surfaced an expected environmental noise: `@vercel/analytics` injects `/_vercel/insights/script.js` which is rewritten by Vercels edge to a real CDN script in production deploys but 404s on `npm run start` against any non-Vercel host (local + CI).

Adds a single-line filter in the `page.on('console')` listener: `if (text.includes('/_vercel/insights')) return;`. Enriches spec comment block with Vercel-edge-rewrite narrative + future-extension guide (e.g., if `@vercel/speed-insights` is later added, ADD another filter line; do NOT disable the analytics package globally).

## Why

PR #118 (`feat(content): update Hero bio + title to Senior Frontend Engineer`) shipped without an automated regression net. The 3 visual regressions (bio 2-paragraph visibility, title-text content match, zero console errors) were verified *manually* via browser-use against the preview-deploy URL. A future bio+title revert would ship undetected.

This PR closes that gap with a CI-gated Chromium-based Playwright integration test that runs on PR + push-to-main + workflow_dispatch via `.github/workflows/e2e-hero.yml`.

## Test plan

All 5 local gates green before merge:

| Gate | Result |
|---|---|
| `npx tsc --noEmit` | OK exit 0 (~5-17s) |
| `npx jest --watchAll=false` | OK 4 suites / 14 tests passed -- `__tests__/e2e/` correctly excluded via testPathIgnorePatterns |
| `npx prettier --check` | OK all 8 changed files clean |
| `npm run build` | OK Next.js 16 production build successful (28s compile, 7 routes prerendered) |
| `npm run test:e2e` | OK 1 passed (~1-2s on chromium prod-built) |

In CI: `.github/workflows/e2e-hero.yml` runs on the PR branch (chromium install + build + e2e + report upload on failure). After commit 2 (`8c4d55f`) the e2e-hero CI check should flip from FAILURE to SUCCESS.

## CI gates for this PR

- `.github/workflows/e2e-hero.yml` (NEW; runs for the first time)
- `.github/workflows/dependency-review.yml`
- `.github/workflows/security-audit.yml` (audit job at `--audit-level=critical` from PR #57)
- `.github/workflows/security-audit.yml#auto-update-next` (Issue #114 polling)
- Vercel deploy preview

## References

- Follows `chore/update-bio-title` (PR #118)
- Mirrors `.github/workflows/prod-smoke.yml` hardening pattern (zero permissions, explicit build split, artifact upload on failure)
- Honors AGENTS.md canonical gh merge pattern (`--admin --squash --delete-branch --body-file`, NO `--yes`)
- Closes the PR #118 bio+title regression gap that was previously only covered by manual browser-use verification
- AGENTS.md gets a new `## Tool quirks: Playwright webServer requires prior npm run build` entry
