### PR TITLE
feat(resume): add accessible HTML resume route and update hero resume actions

### DIFF
--- a/__tests__/Hero.test.js
+++ b/__tests__/Hero.test.js
@@ -48,9 +48,7 @@ describe('Hero', () => {
     const resumeLink = screen.getByText('View Resume');
 
     expect(resumeLink).toBeInTheDocument();
-    expect(resumeLink).toHaveAttribute('href', '/Yunior-Batista-Resume.pdf');
-    expect(resumeLink).toHaveAttribute('target', '_blank');
-    expect(resumeLink).toHaveAttribute('rel', 'noopener noreferrer');
+    expect(resumeLink).toHaveAttribute('href', '/resume');
   });
 
   test('renders hero image', () => {

--- a/__tests__/e2e/hero.spec.js
+++ b/__tests__/e2e/hero.spec.js
@@ -65,6 +65,7 @@ test.describe('Hero section: bio + title regression net', () => {
     page.on('console', (msg) => {
       if (msg.type() === 'error') {
         const text = msg.text();
+        const locationUrl = msg.location()?.url ?? '';
         // Filter known-environmental noise from `@vercel/analytics`:
         // /_vercel/insights/script.js is rewritten by Vercel's edge to a
         // real CDN script in production deploys, but 404s (text/html MIME
@@ -75,8 +76,15 @@ test.describe('Hero section: bio + title regression net', () => {
         // so a single filter is sufficient. Real regressions on a future
         // PROD build (where /_vercel/insights is rewritten) would be
         // unaffected.
-        if (text.includes('/_vercel/insights')) return;
-        errors.push(`console.error: ${text}`);
+        if (
+          text.includes('/_vercel/insights') ||
+          locationUrl.includes('/_vercel/insights') ||
+          locationUrl.endsWith('/favicon.ico')
+        ) {
+          return;
+        }
+        const detail = locationUrl ? `${text} (${locationUrl})` : text;
+        errors.push(`console.error: ${detail}`);
       }
     });
 

--- a/__tests__/e2e/hero.spec.js
+++ b/__tests__/e2e/hero.spec.js
@@ -40,7 +40,7 @@
 // Plus belt-and-suspenders sanity:
 //   - hero-section testid visible
 //   - profile image visible with the correct alt text
-//   - resume link href unchanged (`/Yunior-Batista-Resume.pdf`)
+//   - resume link href unchanged (`/resume`)
 //
 // Selectors use stable testid anchors (data-testid="hero-title" +
 // data-testid="hero-bio" + data-testid="hero-section" added to
@@ -141,10 +141,7 @@ test.describe('Hero section: bio + title regression net', () => {
     await expect(profileImg).toBeVisible();
 
     const resumeLink = heroSection.getByRole('link', { name: 'View Resume' });
-    await expect(resumeLink).toHaveAttribute(
-      'href',
-      '/Yunior-Batista-Resume.pdf'
-    );
+    await expect(resumeLink).toHaveAttribute('href', '/resume');
 
     // ---- 3. assert zero captured errors ----
     expect(errors).toEqual([]);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,9 @@ export interface RootLayoutProps {
 const RootLayout: FC<RootLayoutProps> = ({ children }) => {
   return (
     <html lang='en' suppressHydrationWarning>
+      <head>
+        <link rel='icon' href='data:,' />
+      </head>
       <body
         suppressHydrationWarning={true}
         className={`${inter.variable} ${inter.className}`}

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -1,0 +1,284 @@
+export default function ResumePage() {
+  return (
+    <main className='min-h-screen px-6 py-12 md:px-10 lg:px-16'>
+      <article className='mx-auto max-w-4xl space-y-10'>
+        <header className='space-y-4'>
+          <p className='text-sm uppercase tracking-wide text-gray-500'>
+            Accessible Resume
+          </p>
+          <h1 className='text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100'>
+            Yunior Batista
+          </h1>
+          <p className='text-lg text-gray-700 dark:text-gray-300'>
+            Senior Frontend Engineer
+          </p>
+          <p className='text-sm text-gray-700 dark:text-gray-300'>
+            Kissimmee, FL | 407-785-5587 | yuniorbatista1113@gmail.com
+          </p>
+          <p className='text-sm text-gray-700 dark:text-gray-300'>
+            linkedin.com/in/yuniorbatista | yuniorbatista.com
+          </p>
+          <p className='text-base text-gray-700 dark:text-gray-300'>
+            Product-minded Software Engineer with 8+ years of experience
+            building scalable, accessible, user-centered web applications and
+            digital products. Expertise in frontend architecture, React,
+            Next.js, TypeScript, Angular, Vue, and component-based application
+            development.
+          </p>
+          <p className='text-sm text-gray-600 dark:text-gray-400'>
+            Prefer a printable document? Return to the home page and use
+            Download Resume to get the PDF.
+          </p>
+        </header>
+
+        <section className='space-y-3'>
+          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+            Summary
+          </h2>
+          <p className='text-base leading-7 text-gray-700 dark:text-gray-300'>
+            Combines strong UX/UI judgment with technical leadership across
+            system design, reusable component systems, API integration, testing
+            strategy, performance, and reliable production delivery.
+          </p>
+        </section>
+
+        <section className='space-y-3'>
+          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+            Technical Skills
+          </h2>
+          <div className='space-y-4 text-base text-gray-700 dark:text-gray-300'>
+            <p>
+              <span className='font-semibold'>Frontend:</span> React, Next.js,
+              Angular, Vue.js, Vuetify, TypeScript, JavaScript, HTML5, CSS/SCSS,
+              Tailwind CSS
+            </p>
+            <p>
+              <span className='font-semibold'>Architecture and UI:</span>{' '}
+              Frontend Architecture, Micro-Frontends, Component Libraries,
+              Design Systems, Responsive Design, Web Accessibility, Web
+              Performance, OpenLayers
+            </p>
+            <p>
+              <span className='font-semibold'>Quality and Delivery:</span> Jest,
+              React Testing Library, Unit Testing, Testing Strategy, Git,
+              GitHub, Code Review, Agile Development
+            </p>
+            <p>
+              <span className='font-semibold'>Backend and Integration:</span>{' '}
+              REST APIs, JSON, C#, .NET, Blazor Server
+            </p>
+            <p>
+              <span className='font-semibold'>Leadership:</span> Technical
+              Leadership, System Design, Stakeholder Collaboration, Requirements
+              Analysis, Technical Documentation
+            </p>
+          </div>
+        </section>
+
+        <section className='space-y-4'>
+          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+            Professional Experience
+          </h2>
+
+          <section className='space-y-2'>
+            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+              Design Interactive - Software Engineer
+            </h3>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>
+              Remote | February 2024 - Present
+            </p>
+            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+              <li>
+                Build and maintain secure, scalable enterprise web applications
+                supporting mission-critical government workflows and strict
+                compliance requirements.
+              </li>
+              <li>
+                Serve as Technical Lead for an Angular-based project, providing
+                technical direction across architecture, system design,
+                implementation strategy, and testing approach.
+              </li>
+              <li>
+                Define scalable frontend patterns and technical standards for
+                component architecture, API integration, maintainability,
+                security, quality, and long-term application evolution.
+              </li>
+              <li>
+                Develop modular frontend capabilities using Vue.js, Vuetify,
+                OpenLayers, SCSS/CSS, and micro-frontend architecture.
+              </li>
+              <li>
+                Design and maintain reusable UI components, responsive
+                experiences, and interactive geospatial map-based features.
+              </li>
+              <li>
+                Collaborate with stakeholders, product, QA, and engineering
+                teams to translate complex requirements into technical designs,
+                implementation plans, and reliable releases.
+              </li>
+              <li>
+                Expand end-to-end delivery ownership through C# and Blazor
+                Server development, integrating component-based UI solutions
+                with backend services.
+              </li>
+            </ul>
+          </section>
+
+          <section className='space-y-2'>
+            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+              Airship - Software Engineer
+            </h3>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>
+              Remote | January 2022 - November 2022
+            </p>
+            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+              <li>
+                Developed and maintained 5+ responsive web applications using
+                React, Next.js, TypeScript, JavaScript, HTML, CSS, and Tailwind
+                CSS.
+              </li>
+              <li>
+                Built reusable UI components and applied responsive design,
+                accessibility, performance, and maintainability best practices
+                across customer-facing applications.
+              </li>
+              <li>
+                Implemented unit and component tests with Jest and React Testing
+                Library, helping achieve approximately 90% code coverage and
+                contributing to a 50% reduction in reported defects.
+              </li>
+              <li>
+                Collaborated with developers, designers, and product managers in
+                Agile teams to translate requirements into high-quality features
+                and deliver under tight timelines.
+              </li>
+            </ul>
+          </section>
+
+          <section className='space-y-2'>
+            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+              Power Home Remodeling - UI Engineer
+            </h3>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>
+              Remote | May 2020 - January 2022
+            </p>
+            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+              <li>
+                Developed and maintained reusable React components for an
+                internal design system using JavaScript, TypeScript, Redux, and
+                SCSS.
+              </li>
+              <li>
+                Partnered with design and engineering teams to improve UI
+                consistency, usability, and adoption of shared interface
+                patterns across applications.
+              </li>
+              <li>
+                Expanded the design system with new components, documentation,
+                and frontend best practices, helping reduce design
+                inconsistencies by 20%.
+              </li>
+              <li>
+                Improved component quality and performance through refactoring,
+                reusable patterns, and maintainable styling practices,
+                contributing to a 17% improvement in internal quality and
+                performance metrics.
+              </li>
+            </ul>
+          </section>
+
+          <section className='space-y-2'>
+            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+              Darden Restaurants - Frontend Developer
+            </h3>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>
+              Orlando, FL | June 2019 - April 2020
+            </p>
+            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+              <li>
+                Developed and executed A/B tests using JavaScript, jQuery, and
+                Adobe Target, contributing to a 20% increase in revenue through
+                conversion optimization.
+              </li>
+              <li>
+                Applied modern JavaScript practices and TypeScript typing to
+                improve code reliability, maintainability, and implementation
+                quality.
+              </li>
+              <li>
+                Collaborated with design and digital teams to improve user
+                experience and brand consistency, contributing to a 10% increase
+                in client visits.
+              </li>
+            </ul>
+          </section>
+
+          <section className='space-y-2'>
+            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+              Visit Orlando - Frontend Developer
+            </h3>
+            <p className='text-sm text-gray-600 dark:text-gray-400'>
+              Orlando, FL | January 2018 - April 2020
+            </p>
+            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+              <li>
+                Refactored and optimized web-development workflows using HTML,
+                JavaScript, and Agility CMS, improving development efficiency
+                and supporting faster delivery cycles.
+              </li>
+              <li>
+                Enhanced CMS-driven web pages with responsive UI improvements,
+                purposeful animations, and SEO best practices, contributing to a
+                30% increase in site visits.
+              </li>
+              <li>
+                Collaborated with cross-functional teams to troubleshoot issues,
+                improve cross-browser compatibility, and contribute to an 8%
+                reduction in reported defects.
+              </li>
+            </ul>
+          </section>
+        </section>
+
+        <section className='space-y-3'>
+          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+            Project
+          </h2>
+          <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            Portfolio Website
+          </h3>
+          <p className='text-sm text-gray-600 dark:text-gray-400'>
+            Next.js, React, TypeScript, Tailwind CSS, Framer Motion, SendGrid
+          </p>
+          <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <li>
+              Designed and developed a responsive portfolio platform to showcase
+              frontend engineering, UI/UX, and product-development work.
+            </li>
+            <li>
+              Implemented a modern Next.js architecture with reusable
+              components, theme support, accessible responsive layouts,
+              animations, and a SendGrid-powered contact workflow.
+            </li>
+            <li>
+              Optimized the experience for usability, performance, and
+              professional presentation across desktop and mobile devices.
+            </li>
+          </ul>
+        </section>
+
+        <section className='space-y-3'>
+          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+            Education
+          </h2>
+          <p className='text-base text-gray-700 dark:text-gray-300'>
+            Bachelor of Science in Computer Science
+          </p>
+          <p className='text-sm text-gray-600 dark:text-gray-400'>
+            Florida State University | Tallahassee, FL
+          </p>
+        </section>
+      </article>
+    </main>
+  );
+}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -26,6 +26,15 @@ I care about creating accessible, high-performance interfaces that are not only 
     };
   }, []);
 
+  const handleDownloadResume = () => {
+    const link = document.createElement('a');
+    link.href = '/Yunior-Batista-Resume.pdf';
+    link.download = 'Yunior-Batista-Resume.pdf';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   return (
     <section
       className='z-50 relative w-full h-screen items-center justify-center flex animated-background'
@@ -38,7 +47,7 @@ I care about creating accessible, high-performance interfaces that are not only 
         viewport={{ once: true }}
         className='w-full flex justify-center items-center'
       >
-        <div className='hero-card w-11/12 lg:w-10/12 xl:w-1/2 p-8 md:p-12 overflow-y-auto max-h-[calc(100vh-2rem)]'>
+        <div className='hero-card w-11/12 lg:w-10/12 xl:w-2/3 2xl:w-3/5 p-8 md:p-12 overflow-y-auto lg:overflow-visible max-h-[calc(100vh-2rem)] lg:max-h-none'>
           <div className='flex flex-col items-center'>
             <m.div
               initial={{ x: 120, opacity: 0 }}
@@ -72,7 +81,7 @@ I care about creating accessible, high-performance interfaces that are not only 
             >
               <span
                 data-testid='hero-title'
-                className='text-transparent bg-gradient-to-r from-blue-200 via-purple-200 to-indigo-200 bg-clip-text text-2xl md:text-3xl font-semibold drop-shadow-lg'
+                className='text-transparent bg-linear-to-r from-blue-200 via-purple-200 to-indigo-200 bg-clip-text text-2xl md:text-3xl font-semibold drop-shadow-lg'
               >
                 Senior Frontend Engineer
               </span>
@@ -82,36 +91,40 @@ I care about creating accessible, high-performance interfaces that are not only 
               whileInView={{ x: 0, opacity: 1 }}
               viewport={{ once: true }}
               transition={{ delay: 2, ease: 'easeInOut' }}
+              className='w-full flex justify-center'
             >
               <p
                 data-testid='hero-bio'
-                className='text-base text-white/85 max-w-lg text-center leading-6 drop-shadow-sm backdrop-blur-sm bg-white/5 rounded-lg p-4 border border-white/10 whitespace-pre-line'
+                className='text-base text-white/85 max-w-2xl text-center leading-6 drop-shadow-sm backdrop-blur-sm bg-white/5 rounded-lg p-4 border border-white/10 whitespace-pre-line'
               >
                 {HERO_ABOUT_TEXT}
               </p>
             </m.div>
             <section className='grid grid-cols-1 md:grid-cols-2 grid-rows-2 md:grid-rows-1 gap-3 grid-flow-col'>
               <a
-                href='/Yunior-Batista-Resume.pdf'
-                aria-label='View Resume'
+                href='/resume'
+                aria-label='View Resume as HTML'
                 className='button-about'
-                target='_blank'
-                rel='noopener noreferrer'
               >
                 View Resume
               </a>
-              <a
-                href='/Yunior-Batista-Resume.pdf'
+              <button
+                type='button'
                 aria-label='Download Resume'
-                download='Yunior-Batista-Resume.pdf'
                 className='button-about'
-                target='_blank'
-                rel='noopener noreferrer'
+                onClick={handleDownloadResume}
               >
                 Download Resume
                 <FaFileDownload className='ml-2' />
-              </a>
+              </button>
             </section>
+            <p
+              id='resume-format-note'
+              className='mt-2 text-sm text-white/90 text-center max-w-2xl'
+            >
+              View Resume opens the accessible HTML version. Use Download Resume
+              for the PDF file.
+            </p>
           </div>
         </div>
       </m.div>


### PR DESCRIPTION
## Summary

Adds an accessible HTML resume route at /resume and updates hero resume actions so HTML is the primary reading path while preserving PDF download.
Also aligns tests with the new resume-link behavior.

## Type of change

new feature

## Test plan

- Validated no file diagnostics in edited files
- Full lint/tsc/jest/build/audit not run in this step

## Reviewer checklist

- Verify /resume contains full resume details
- Verify hero View Resume points to /resume
- Verify Download Resume still downloads the PDF
