### PR TITLE
chore(deps): ignore typescript v7 in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "typescript"
+        versions:
+          - ">=7.0.0"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
Dependabot ignore rule for TypeScript v7.
TypeScript 7 (native Go compiler) drops the legacy compiler API Next.js 16 needs, so bumping typescript to >=7 breaks the Next.js build. Closing PR #127 and ignoring >=7 to prevent re-proposal until Next.js supports the new compiler API.
