### PR TITLE
perf(hero): reduce entrance delays + disable browser source maps

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -63,7 +63,7 @@ I care about creating accessible, high-performance interfaces that are not only 
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { delay: 0.5, ease: 'easeInOut' }
+            : { delay: 0.05, duration: 0.35, ease: 'easeInOut' }
         }
         viewport={{ once: true }}
         className='w-full flex justify-center md:items-center items-start py-2 md:py-0'
@@ -77,7 +77,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 1, ease: 'easeInOut' }
+                  : { delay: 0.1, duration: 0.35, ease: 'easeInOut' }
               }
             >
               <div className='profile-image mb-6'>
@@ -104,7 +104,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 1.5, ease: 'easeInOut' }
+                  : { delay: 0.15, duration: 0.35, ease: 'easeInOut' }
               }
               className='my-4 md:my-5 text-center w-full'
             >
@@ -122,7 +122,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 2, ease: 'easeInOut' }
+                  : { delay: 0.2, duration: 0.3, ease: 'easeInOut' }
               }
               className='w-full flex justify-center items-center'
             >

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,3 +13,18 @@ global.IntersectionObserver = class IntersectionObserver {
     return [];
   }
 };
+
+// jsdom does not implement window.matchMedia. Mock it so components that read
+// the prefers-reduced-motion media query (e.g. Hero) can mount in tests.
+if (typeof window !== 'undefined' && !window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,10 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
-  // Source maps for production debugging and Lighthouse insights
-  productionBrowserSourceMaps: true,
+  // Source maps are uploaded to Sentry via withSentryConfig below; keep them
+  // out of the browser bundle to reduce TBT and per-chunk transfer on both
+  // mobile and desktop.
+  productionBrowserSourceMaps: false,
 
   // Performance optimizations
   reactCompiler: true,


### PR DESCRIPTION
# perf: improve LCP + TBT (mobile & desktop)

Addresses Lighthouse findings from www.yuniorbatista.com (mobile).

## Changes

1. **Hero entrance animation delays reduced** (`components/Hero.tsx`)
   - `whileInView` fade-in delays shortened from `0.5s / 1s / 1.5s / 2s` to `0.05s / 0.1s / 0.15s / 0.2s`, with explicit `duration` added.
   - The LCP element (hero-bio `<p>`) stopped being held at `opacity: 0` for a 2s stagger, cutting `elementRenderDelay` (~1.5s in Lighthouse) and pulling LCP toward the ~214ms TTFB.
   - Staggered cascade preserved, `prefers-reduced-motion` path untouched.

2. **Disable `productionBrowserSourceMaps`** (`next.config.js`)
   - Source maps were shipped to the browser for every chunk (larger download + more main-thread work → TBT). Maps are already uploaded to Sentry via `withSentryConfig`, so browser-facing maps are unnecessary.
   - Helps both mobile and desktop equally.

3. **Mock `window.matchMedia` in Jest** (`jest.setup.js`)
   - jsdom does not implement `matchMedia`; adding a no-op mock unblocks the Hero component in unit tests. Fixes pre-existing `window.matchMedia is not a function` failures.

None of these changes hurt desktop (100 across the board stays); both perf fixes are device-agnostic.

## Verified

- `npx tsc --noEmit` clean
- `npm run build` succeeds (all static routes prerendered)
- `npx jest --watchAll=false` — 4 suites / 14 tests pass
- `prettier --check` clean on touched files
