### PR TITLE
revert(revert): perf/hero changes for A/B TBT measurement

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -63,7 +63,7 @@ I care about creating accessible, high-performance interfaces that are not only 
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { delay: 0.05, duration: 0.35, ease: 'easeInOut' }
+            : { delay: 0.5, ease: 'easeInOut' }
         }
         viewport={{ once: true }}
         className='w-full flex justify-center md:items-center items-start py-2 md:py-0'
@@ -77,7 +77,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 0.1, duration: 0.35, ease: 'easeInOut' }
+                  : { delay: 1, ease: 'easeInOut' }
               }
             >
               <div className='profile-image mb-6'>
@@ -104,7 +104,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 0.15, duration: 0.35, ease: 'easeInOut' }
+                  : { delay: 1.5, ease: 'easeInOut' }
               }
               className='my-4 md:my-5 text-center w-full'
             >
@@ -122,7 +122,7 @@ I care about creating accessible, high-performance interfaces that are not only 
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { delay: 0.2, duration: 0.3, ease: 'easeInOut' }
+                  : { delay: 2, ease: 'easeInOut' }
               }
               className='w-full flex justify-center items-center'
             >

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,18 +13,3 @@ global.IntersectionObserver = class IntersectionObserver {
     return [];
   }
 };
-
-// jsdom does not implement window.matchMedia. Mock it so components that read
-// the prefers-reduced-motion media query (e.g. Hero) can mount in tests.
-if (typeof window !== 'undefined' && !window.matchMedia) {
-  window.matchMedia = (query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: () => {},
-    removeListener: () => {},
-    addEventListener: () => {},
-    removeEventListener: () => {},
-    dispatchEvent: () => false,
-  });
-}

--- a/next.config.js
+++ b/next.config.js
@@ -1,10 +1,8 @@
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
-  // Source maps are uploaded to Sentry via withSentryConfig below; keep them
-  // out of the browser bundle to reduce TBT and per-chunk transfer on both
-  // mobile and desktop.
-  productionBrowserSourceMaps: false,
+  // Source maps for production debugging and Lighthouse insights
+  productionBrowserSourceMaps: true,
 
   // Performance optimizations
   reactCompiler: true,


### PR DESCRIPTION
# Revert #131 (perf: hero delays + source maps) for A/B measurement

Reverts PR #131 to test empirically whether it caused the reported TBT increase (user: 83 -> 65, TBT ~1390ms).

Nothing in #131 should raise TBT (removing source maps + shortening CSS delays strictly reduce work), so this A/B verifies whether the regression is attributable to the perf PR or to environment noise / concurrent dependency merges (#125-129: next 16.3, eslint 10).
