### PR TITLE
perf: remove framer-motion, migrate to CSS keyframes

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -117,6 +117,60 @@ html {
     }
   }
 
+  /* Generic fade-up reveal for below-the-fold sections/cards. Replaces
+     framer-motion whileInView; plays on load (off the critical path). */
+  .section-reveal {
+    opacity: 1;
+    animation: sectionReveal 0.7s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+
+  .project-reveal {
+    opacity: 1;
+    animation: sectionReveal 0.8s ease-in-out 0.15s both;
+  }
+
+  @keyframes sectionReveal {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* Form success/status entrance. */
+  .pop-in {
+    animation: popIn 0.35s ease-out both;
+  }
+
+  @keyframes popIn {
+    from {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .slide-in {
+    animation: slideIn 0.3s ease-out both;
+  }
+
+  @keyframes slideIn {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
   /* Glassmorphism Hero Card */
   .hero-card {
     background: rgba(255, 255, 255, 0.08);
@@ -186,7 +240,11 @@ html {
     .hero-anim-1,
     .hero-anim-2,
     .hero-anim-3,
-    .hero-anim-4 {
+    .hero-anim-4,
+    .section-reveal,
+    .project-reveal,
+    .pop-in,
+    .slide-in {
       animation: none;
       opacity: 1;
       transform: none;

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { m } from 'framer-motion';
-import { FormEvent, memo, useCallback, useEffect, useState } from 'react';
+import { FormEvent, memo, useCallback, useState } from 'react';
 import { FaRegPaperPlane } from 'react-icons/fa';
 
 const ContactForm = memo(() => {
@@ -17,15 +16,6 @@ const ContactForm = memo(() => {
     email: '',
     message: '',
   });
-  const [shouldReduceMotion, setShouldReduceMotion] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const update = () => setShouldReduceMotion(mq.matches);
-    update();
-    mq.addEventListener('change', update);
-    return () => mq.removeEventListener('change', update);
-  }, []);
 
   const fullNameErrorId = 'full-name-error';
   const emailErrorId = 'email-error';
@@ -131,17 +121,7 @@ const ContactForm = memo(() => {
         Let&apos;s Connect
       </h1>
 
-      <m.div
-        initial={shouldReduceMotion ? false : { opacity: 0, y: 20 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={
-          shouldReduceMotion
-            ? { duration: 0 }
-            : { duration: 0.8, ease: 'easeOut' }
-        }
-        className='relative bg-white dark:bg-[#0c0f1e] rounded-2xl shadow-2xl overflow-hidden'
-      >
+      <div className='relative bg-white dark:bg-[#0c0f1e] rounded-2xl shadow-2xl overflow-hidden section-reveal'>
         {/* Desktop Split Layout */}
         <div className='lg:grid lg:grid-cols-2 lg:min-h-150'>
           {/* 3D Envelope Section */}
@@ -233,14 +213,7 @@ const ContactForm = memo(() => {
             <div className='absolute -top-8 left-8 right-8 lg:hidden bg-white/10 dark:bg-gray-900/10 backdrop-blur-sm rounded-t-2xl h-8' />
 
             {sending ? (
-              <m.div
-                initial={
-                  shouldReduceMotion ? false : { scale: 0.8, opacity: 0 }
-                }
-                animate={{ scale: 1, opacity: 1 }}
-                transition={shouldReduceMotion ? { duration: 0 } : undefined}
-                className='flex flex-col items-center justify-center w-full text-center'
-              >
+              <div className='flex flex-col items-center justify-center w-full text-center pop-in'>
                 <div className='w-20 h-20 bg-linear-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center mb-6'>
                   <FaRegPaperPlane className='text-2xl text-white animate-bounce' />
                 </div>
@@ -250,7 +223,7 @@ const ContactForm = memo(() => {
                 <p className='text-gray-600 dark:text-gray-400'>
                   Thank you for reaching out. I&apos;ll get back to you soon.
                 </p>
-              </m.div>
+              </div>
             ) : (
               <div className='w-full max-w-lg'>
                 <form
@@ -392,33 +365,26 @@ const ContactForm = memo(() => {
 
                   {/* Status Message */}
                   {message && (
-                    <m.div
-                      initial={
-                        shouldReduceMotion ? false : { opacity: 0, y: 10 }
-                      }
-                      animate={{ opacity: 1, y: 0 }}
-                      transition={
-                        shouldReduceMotion ? { duration: 0 } : undefined
-                      }
+                    <div
                       role={message.includes('Error') ? 'alert' : 'status'}
                       aria-live={
                         message.includes('Error') ? 'assertive' : 'polite'
                       }
-                      className={`p-4 rounded-xl text-sm font-medium ${
+                      className={`p-4 rounded-xl text-sm font-medium slide-in ${
                         message.includes('Error')
                           ? 'bg-red-50 text-red-700 border border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800'
                           : 'bg-green-50 text-green-700 border border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800'
                       }`}
                     >
                       {message}
-                    </m.div>
+                    </div>
                   )}
                 </form>
               </div>
             )}
           </main>
         </div>
-      </m.div>
+      </div>
     </section>
   );
 });

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -1,6 +1,5 @@
 'use client';
 // Using custom glassmorphism cards and buttons
-import { m } from 'framer-motion';
 import Image from 'next/image';
 import { lazy, memo, useState } from 'react';
 
@@ -30,13 +29,7 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
   } = project;
 
   return (
-    <m.div
-      initial={{ opacity: 0 }}
-      whileInView={{ opacity: 1 }}
-      transition={{ delay: 0.2, ease: 'easeInOut', duration: 0.8 }}
-      viewport={{ once: true }}
-      className={featured ? 'w-full' : undefined}
-    >
+    <div className={featured ? 'w-full project-reveal' : 'project-reveal'}>
       {featured ? (
         /* Featured: landscape on md+, stacked on mobile */
         <div
@@ -61,7 +54,9 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
             />
           </div>
           <div className='p-8 flex flex-col justify-center gap-4'>
-            <span className='text-xs font-semibold uppercase tracking-widest text-indigo-400'>Featured Project</span>
+            <span className='text-xs font-semibold uppercase tracking-widest text-indigo-400'>
+              Featured Project
+            </span>
             <h4 className='text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-white'>
               {name}
             </h4>
@@ -76,7 +71,10 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
               ))}
             </div>
             <button
-              onClick={(e) => { e.stopPropagation(); setOpenModal(true); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setOpenModal(true);
+              }}
               className='modern-button w-fit mt-2 hover:cursor-pointer px-8'
             >
               View Details
@@ -135,7 +133,7 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
           liveDemoLink={liveDemoLink}
         />
       )}
-    </m.div>
+    </div>
   );
 });
 

--- a/components/ThemeProviderWrapper.tsx
+++ b/components/ThemeProviderWrapper.tsx
@@ -1,19 +1,9 @@
 'use client';
-import { LazyMotion } from 'framer-motion';
 import { RootLayoutProps } from '../app/layout';
 import MyThemeProvider from './ThemeProvider';
 
-const loadFeatures = () =>
-  import('framer-motion').then((res) => res.domAnimation);
-
 const ThemeProviderWrapper = ({ children }: RootLayoutProps) => {
-  return (
-    <MyThemeProvider attribute='class'>
-      <LazyMotion features={loadFeatures} strict>
-        {children}
-      </LazyMotion>
-    </MyThemeProvider>
-  );
+  return <MyThemeProvider attribute='class'>{children}</MyThemeProvider>;
 };
 
 export default ThemeProviderWrapper;

--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
   // Performance optimizations
   reactCompiler: true,
   experimental: {
-    optimizePackageImports: ['framer-motion', 'react-icons'],
+    optimizePackageImports: ['react-icons'],
     turbopackFileSystemCacheForDev: true,
     optimizeCss: true,
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "eslint": "^10.8.0",
         "eslint-config-next": "^16.2.12",
         "eslint-plugin-prettier": "^5.5.6",
-        "framer-motion": "^12.43.0",
         "next": "^16.3.0",
         "next-themes": "^0.4.6",
         "postcss": "^8.5.25",
@@ -1047,9 +1046,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1065,9 +1061,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1085,9 +1078,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1103,9 +1093,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1123,9 +1110,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1141,9 +1125,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1161,9 +1142,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1180,9 +1158,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1198,9 +1173,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1224,9 +1196,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1248,9 +1217,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1274,9 +1240,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1298,9 +1261,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1324,9 +1284,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1349,9 +1306,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1373,9 +1327,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2347,9 +2298,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2365,9 +2313,6 @@
       "integrity": "sha512-tXXGKJw0m37O0eKJARVTX/TheKPhz0QFVtVVZXmOig+9YKLQOSP6hvf2pxv5DO7CLEJyTHx3Pg043CDQkv1G4Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2385,9 +2330,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2403,9 +2345,6 @@
       "integrity": "sha512-sjo++Xx+lomlPs3HRsHWhVDyGG6ms1kGW5EtHLERdII8AyG1i+f6aq68xHREO6AEMlhjTNEWBSmfJfqm9orf7g==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6865,33 +6804,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "12.43.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
-      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.43.0",
-        "motion-utils": "^12.39.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9729,21 +9641,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
-      "license": "MIT"
-    },
-    "node_modules/motion-dom": {
-      "version": "12.43.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
-      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.39.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.39.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "eslint": "^10.8.0",
     "eslint-config-next": "^16.2.12",
     "eslint-plugin-prettier": "^5.5.6",
-    "framer-motion": "^12.43.0",
     "next": "^16.3.0",
     "next-themes": "^0.4.6",
     "postcss": "^8.5.25",


### PR DESCRIPTION
# perf: remove framer-motion, use CSS keyframes everywhere

Removes the last heavy JS animation dependency from the client bundle. framer-motion was already dropped from Hero in #134; this covers the remaining usages and uninstalls the package.

## Changes

- **Project.tsx** — replace `motion.div` `whileInView` fade with `.project-reveal` (`@keyframes sectionReveal`)
- **ContactForm.tsx** — replace 3 `motion.div`s (card fade-up → `.section-reveal`, success scale → `.pop-in`, status → `.slide-in`); drop the `matchMedia` reduced-motion state (CSS handles it via `prefers-reduced-motion`)
- **ThemeProviderWrapper.tsx** — remove the `LazyMotion` provider wrapper
- **package.json / lockfile** — uninstall framer-motion; remove from `optimizePackageImports` in next.config.js

## Verified

- `tsc --noEmit` clean
- `jest --watchAll=false` 14/14 pass
- `npm run build` succeeds; compiled JS chunks reference **0** framer-motion
- `heroEntrance`/`sectionReveal`/`popIn`/`slideIn` keyframes present in built CSS
- Total built JS ≈ 716K

## Impact

Removes the framer-motion vendor bundle from the critical path and eliminates rAF / IntersectionObserver main-thread work in the initial render — targeting the remaining TBT. All entrance animations now run on the compositor via `@keyframes` and honor `prefers-reduced-motion`.