### PR TITLE
feat(ui): editorial hero + generic bento/grid projects

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,59 @@
 // Type: Layout
 import { Analytics as VercelAnalytics } from '@vercel/analytics/react';
-import { Inter } from 'next/font/google';
+import { Inter, JetBrains_Mono, Space_Grotesk } from 'next/font/google';
+import type { Metadata } from 'next';
 import { FC, ReactNode } from 'react';
 import ThemeProviderWrapper from '../components/ThemeProviderWrapper';
 import './styles/globals.css';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
 
-type MetadataProps = {
-  title: string;
-  description: string;
-};
+const spaceGrotesk = Space_Grotesk({
+  subsets: ['latin'],
+  variable: '--font-space-grotesk',
+  weight: ['400', '500', '600', '700'],
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ['latin'],
+  variable: '--font-jetbrains-mono',
+  weight: ['400', '500'],
+});
+
+type MetadataProps = Metadata;
 
 export const metadata: MetadataProps = {
-  title: "Yunior Batista's Portfolio",
-  description: 'A portfolio to showcase some of my projects and experiences',
+  metadataBase: new URL('https://www.yuniorbatista.com'),
+  title: 'Yunior Batista — Senior Frontend Engineer',
+  description:
+    'Product-minded Senior Frontend Engineer building scalable, accessible, high-performance web apps with React, Next.js, and TypeScript.',
+  alternates: {
+    canonical: 'https://www.yuniorbatista.com',
+  },
+  openGraph: {
+    title: 'Yunior Batista — Senior Frontend Engineer',
+    description:
+      'Product-minded Senior Frontend Engineer building accessible, high-performance web apps with React, Next.js, and TypeScript.',
+    url: 'https://www.yuniorbatista.com',
+    siteName: 'Yunior Batista',
+    locale: 'en_US',
+    type: 'website',
+    images: [
+      {
+        url: '/og-preview',
+        width: 1200,
+        height: 630,
+        alt: 'Yunior Batista — Senior Frontend Engineer',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Yunior Batista — Senior Frontend Engineer',
+    description:
+      'Product-minded Senior Frontend Engineer building accessible, high-performance web apps with React, Next.js, and TypeScript.',
+    images: ['/og-preview'],
+  },
 };
 
 export interface RootLayoutProps {
@@ -26,10 +65,28 @@ const RootLayout: FC<RootLayoutProps> = ({ children }) => {
     <html lang='en' suppressHydrationWarning>
       <head>
         <link rel='icon' href='data:,' />
+        <script
+          type='application/ld+json'
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'Person',
+              name: 'Yunior Batista',
+              jobTitle: 'Senior Frontend Engineer',
+              url: 'https://www.yuniorbatista.com',
+              description:
+                'Product-minded Senior Frontend Engineer building accessible, high-performance web apps with React, Next.js, and TypeScript.',
+              sameAs: [
+                'https://github.com/batistaDev1113',
+                'https://www.linkedin.com/in/yunior-profile/',
+              ],
+            }),
+          }}
+        />
       </head>
       <body
         suppressHydrationWarning={true}
-        className={`${inter.variable} ${inter.className}`}
+        className={`${inter.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} ${inter.className}`}
       >
         <a
           href='#main-content'

--- a/app/og-preview/route.tsx
+++ b/app/og-preview/route.tsx
@@ -1,0 +1,64 @@
+import { ImageResponse } from 'next/og';
+
+export const runtime = 'nodejs';
+export const alt = 'Yunior Batista — Senior Frontend Engineer';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export async function GET() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          padding: '64px 80px',
+          background:
+            'linear-gradient(135deg, #07090f 0%, #111623 45%, #1e1b4b 100%)',
+          color: 'white',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 800,
+            letterSpacing: -1,
+            display: 'flex',
+            width: '100%',
+          }}
+        >
+          Yunior Batista
+        </div>
+        <div
+          style={{
+            marginTop: 16,
+            fontSize: 28,
+            display: 'flex',
+            color: '#a5b4fc',
+            letterSpacing: 2,
+          }}
+        >
+          SENIOR FRONTEND ENGINEER
+        </div>
+        <div
+          style={{
+            marginTop: 48,
+            fontSize: 24,
+            display: 'flex',
+            color: '#cbd5e1',
+            maxWidth: 800,
+          }}
+        >
+          Building accessible, high-performance web experiences with React,
+          Next.js & TypeScript.
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import dynamic from 'next/dynamic';
 import Hero from '../components/Hero';
 import Navigation from '../components/Navigation';
 import Projects from '../components/Projects';
+import Toolbox from '../components/Toolbox';
 
 const ContactForm = dynamic(() => import('../components/ContactForm'));
 const FooterComponent = dynamic(() => import('../components/FooterComponent'));
@@ -11,10 +12,11 @@ export default function Home() {
     <main
       id='main-content'
       tabIndex={-1}
-      className='flex min-h-screen flex-col items-center w-full scroll-smooth dark:bg-white/5'
+      className='flex min-h-screen flex-col items-center w-full scroll-smooth dark:bg-night'
     >
       <Navigation />
       <Hero />
+      <Toolbox />
       <Projects />
       <ContactForm />
       <FooterComponent />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,14 @@ export default function Home() {
       className='flex min-h-screen flex-col items-center w-full scroll-smooth dark:bg-night'
     >
       <Navigation />
-      <Hero />
+      <div className='relative w-full'>
+        <Hero />
+        {/* Curved seam: the light content below "dips" up into the dark hero */}
+        <div
+          aria-hidden='true'
+          className='relative z-40 -mt-16 sm:-mt-20 lg:-mt-24 h-16 sm:h-20 lg:h-24 bg-light-surface dark:bg-night rounded-t-[100%] pointer-events-none'
+        />
+      </div>
       <Toolbox />
       <Projects />
       <ContactForm />

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -9,10 +9,40 @@
 @source "../../components/**/*.{js,jsx,ts,tsx}";
 @source "../../app/**/*.{js,jsx,ts,tsx}";
 
-/* Empty @theme block: this project does NOT define custom colors, fonts,
-   or spacing scales relative to Tailwind defaults. v4 treats an empty
-   @theme block as "inherit all defaults from the engine". Safe. */
-@theme {}
+/* Design tokens. Single indigo -> violet anchor (primary), layered dark
+   surfaces, and font families wired to the next/font variables loaded in
+   app/layout.tsx. Tailwind v4 emits utilities from the theme variables
+   (e.g. --color-primary -> bg-primary/text-primary, --font-display ->
+   font-display). */
+@theme {
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-space-grotesk), var(--font-inter), sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+
+  --color-primary-50: #eef2ff;
+  --color-primary-100: #e0e7ff;
+  --color-primary-200: #c7d2fe;
+  --color-primary-300: #a5b4fc;
+  --color-primary-400: #818cf8;
+  --color-primary-500: #6366f1;
+  --color-primary-600: #4f46e5;
+  --color-primary-700: #4338ca;
+  --color-primary-800: #3730a3;
+  --color-primary-900: #312e81;
+
+  --color-violet-a: #8b5cf6;
+  --color-violet-b: #a78bfa;
+
+  /* Layered surfaces for dark mode: base -> raised -> elevated. */
+  --color-night: #07090f;
+  --color-surface: #0b0e16;
+  --color-raised: #111623;
+  --color-border: #1d2434;
+  --color-border-strong: #2a3347;
+
+  /* Light mode surfaces: near-white base + soft borders. */
+  --color-light-surface: #ffffff;
+}
 
 * {
   box-sizing: border-box;
@@ -33,7 +63,7 @@
 }
 
 body {
-    @apply bg-white dark:bg-[#07090f];
+    @apply bg-light-surface dark:bg-night text-slate-900 dark:text-slate-100 transition-colors duration-300;
 }
 
 html {
@@ -51,7 +81,7 @@ html {
   }
 
   ::-webkit-scrollbar-thumb {
-    background-image: linear-gradient(to bottom, #86efac, #3b82f6, #9333ea);
+    background-image: linear-gradient(to bottom, var(--color-primary-500), var(--color-violet-a));
     border-radius: 20px;
     width: 10px;
   }
@@ -63,22 +93,82 @@ html {
     height: unset !important;
   }
 
-  .flowbite-card div:first-child {
-    padding: 0 !important;
+  /* Minimal, globally-consistent focus treatment. */
+  :focus-visible {
+    outline: 2px solid var(--color-primary-500);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  /* Mono eyebrow label: `// 01 · PROJECTS` used above section titles. */
+  .eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--color-primary-500);
+  }
+
+  .dark .eyebrow {
+    color: var(--color-violet-b);
+  }
+
+  /* Fluid display headings: clamp() scale, tight tracking, display font. */
+  .fluid-title {
+    font-family: var(--font-display);
+    font-weight: 600;
+    letter-spacing: -0.02em;
+    line-height: 1.1;
+    font-size: clamp(1.75rem, 3.5vw + 1rem, 3rem);
+  }
+
+  .fluid-subtitle {
+    font-family: var(--font-display);
+    letter-spacing: -0.015em;
+    line-height: 1.25;
+  }
+
+  /* Soft elevation for raised cards (project + skill cards, light mode). */
+  .card-elevated {
+    background: var(--color-light-surface);
+    border: 1px solid var(--color-primary-100);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
+      0 8px 24px rgba(15, 23, 42, 0.06);
+  }
+
+  .dark .card-elevated {
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+  }
+
+  /* Subtle top accent bar for branded cards. */
+  .accent-top::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(
+      90deg,
+      var(--color-primary-500),
+      var(--color-violet-a)
+    );
   }
 
   .button-about {
-    @apply my-4 inline-flex items-center justify-center px-8 py-3 text-base text-center text-white border-none rounded-lg focus:ring-4 focus:ring-purple-300 dark:focus:ring-purple-800 transition-all duration-300 ease-out;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    @apply my-4 inline-flex items-center justify-center px-8 py-3 text-base text-center text-white border-none rounded-lg transition-all duration-300 ease-out;
+    background: linear-gradient(135deg, var(--color-primary-600) 0%, var(--color-violet-a) 100%);
     backdrop-filter: blur(10px);
-    box-shadow: 0 10px 25px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 10px 25px rgba(79, 70, 229, 0.3);
     transform: translateY(0);
   }
 
   .button-about:hover {
     transform: translateY(-2px) scale(1.02);
-    box-shadow: 0 15px 35px rgba(102, 126, 234, 0.4);
-    background: linear-gradient(135deg, #7c3aed 0%, #8b5cf6 100%);
+    box-shadow: 0 15px 35px rgba(79, 70, 229, 0.4);
+    background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-violet-b) 100%);
   }
 
   /* Hero entrance: pure-CSS staggered fade-up. Runs on the compositor via
@@ -186,9 +276,19 @@ html {
     box-shadow: 0 25px 60px rgba(0, 0, 0, 0.6);
   }
 
-  /* Animated Gradient Background */
+  /* Animated Gradient Background.
+     Uses the indigo/violet anchor in both light and dark modes (the hero is
+     intentionally dark in both themes — the card + text are white-on-dark). */
   .animated-background {
-    background: linear-gradient(-45deg, #020617, #0f0c29, #0a0f1e, #140d2e);
+    background: linear-gradient(
+      -45deg,
+      #020617,
+      #0f0c29,
+      rgba(79, 70, 229, 0.18),
+      #0a0f1e,
+      rgba(139, 92, 246, 0.16),
+      #140d2e
+    );
     background-size: 300% 300%;
     background-position: 0% 50%;
     animation: gradientShift 16s ease-in-out infinite;
@@ -225,7 +325,7 @@ html {
     left: -3px;
     right: -3px;
     bottom: -3px;
-    background: linear-gradient(45deg, #4f46e5, #7c3aed, #2563eb);
+    background: linear-gradient(45deg, var(--color-primary-500), var(--color-violet-a), var(--color-primary-600));
     border-radius: 50%;
     z-index: -1;
   }
@@ -266,30 +366,44 @@ html {
 
   /* Modern Project Cards */
   .project-card {
-    background: rgba(255, 255, 255, 0.8);
-    backdrop-filter: blur(16px);
-    border: 1px solid rgba(0, 0, 0, 0.1);
+    background: var(--color-light-surface);
+    border: 1px solid var(--color-primary-100);
     border-radius: 20px;
     overflow: hidden;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.05);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
+      0 8px 24px rgba(15, 23, 42, 0.06);
   }
 
   .dark .project-card {
-    background: rgba(13, 17, 42, 0.65);
-    border: 1px solid rgba(99, 102, 241, 0.18);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
   }
 
   .project-card:hover {
-    transform: translateY(-8px) scale(1.02);
-    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.2);
+    transform: translateY(-6px);
+    box-shadow: 0 20px 45px rgba(79, 70, 229, 0.12);
+    border-color: var(--color-primary-300);
+  }
+
+  .dark .project-card:hover {
+    border-color: var(--color-border-strong);
+    box-shadow: 0 25px 55px rgba(0, 0, 0, 0.5);
   }
 
   .project-image-overlay {
     position: relative;
     overflow: hidden;
+  }
+
+  .project-image-overlay img {
+    transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .project-card:hover .project-image-overlay img {
+    transform: scale(1.05);
   }
 
   .project-image-overlay::after {
@@ -301,8 +415,8 @@ html {
     bottom: 0;
     background: linear-gradient(
       135deg,
-      rgba(79, 70, 229, 0.1) 0%,
-      rgba(124, 58, 237, 0.1) 100%
+      rgba(79, 70, 229, 0.12) 0%,
+      rgba(139, 92, 246, 0.12) 100%
     );
     opacity: 0;
     transition: opacity 0.3s ease;
@@ -313,7 +427,7 @@ html {
   }
 
   .modern-button {
-    background: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+    background: linear-gradient(135deg, var(--color-primary-600) 0%, var(--color-violet-a) 100%);
     border: none;
     color: white;
     padding: 0.75rem 1.5rem;
@@ -326,24 +440,25 @@ html {
   .modern-button:hover {
     transform: translateY(-2px);
     box-shadow: 0 8px 25px rgba(79, 70, 229, 0.4);
-    background: linear-gradient(135deg, #6366f1 0%, #8b5cf6 100%);
+    background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-violet-b) 100%);
   }
 
   .tech-tag {
-    background: rgba(79, 70, 229, 0.08);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    background: rgba(79, 70, 229, 0.06);
     backdrop-filter: blur(10px);
-    border: 1px solid rgba(79, 70, 229, 0.2);
-    border-radius: 20px;
-    padding: 0.25rem 0.75rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: #4f46e5;
+    border: 1px solid rgba(79, 70, 229, 0.16);
+    border-radius: 6px;
+    padding: 0.3rem 0.6rem;
+    color: var(--color-primary-700);
   }
 
   .dark .tech-tag {
-    background: rgba(99, 102, 241, 0.12);
-    border: 1px solid rgba(139, 92, 246, 0.28);
-    color: #c4b5fd;
+    background: rgba(129, 140, 248, 0.08);
+    border: 1px solid rgba(167, 139, 250, 0.22);
+    color: var(--color-primary-300);
   }
 
 /* On touch devices, keep scrolling but hide visual scrollbars to avoid
@@ -424,4 +539,54 @@ html {
 
 .envelope-3d:hover .envelope-flap {
   transform: rotateX(-35deg) translateZ(5px);
+}
+
+/* Toolbox rail: natively scrollable (overflow-x: auto) so every tool is
+   reachable without relying on an animation. Styled thin scrollbar + edge
+   fade mask. Respects prefers-reduced-motion by construction (no motion). */
+.toolbox-rail {
+  display: flex;
+  gap: 0.75rem;
+  overflow-x: auto;
+  padding: 0.25rem 0 1rem;
+  scrollbar-width: thin;
+  scrollbar-color: var(--color-primary-500) transparent;
+}
+
+.toolbox-rail::-webkit-scrollbar {
+  height: 6px;
+}
+
+.toolbox-rail::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.toolbox-rail::-webkit-scrollbar-thumb {
+  background: var(--color-primary-500);
+  border-radius: 9999px;
+}
+
+.toolbox-item {
+  flex: 0 0 auto;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: var(--color-primary-700);
+  background: rgba(79, 70, 229, 0.05);
+  border: 1px solid rgba(79, 70, 229, 0.14);
+  border-radius: 9999px;
+  padding: 0.45rem 1rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.dark .toolbox-item {
+  color: var(--color-primary-200);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+}
+
+.toolbox-item:hover {
+  border-color: var(--color-primary-400);
+  background: rgba(79, 70, 229, 0.1);
 }

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -171,6 +171,23 @@ html {
     background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-violet-b) 100%);
   }
 
+  /* Quiet secondary CTA: underline on hover, no gradient fill. Sits
+     alongside .button-about as the "less important" action. */
+  .button-quiet {
+    @apply inline-flex items-center justify-center px-5 py-3 text-base text-center rounded-lg transition-all duration-300 ease-out;
+    color: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    background: rgba(255, 255, 255, 0.04);
+    backdrop-filter: blur(8px);
+  }
+
+  .button-quiet:hover {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.45);
+    background: rgba(255, 255, 255, 0.1);
+    transform: translateY(-2px);
+  }
+
   /* Hero entrance: pure-CSS staggered fade-up. Runs on the compositor via
      @keyframes (no JS / framer-motion on the initial critical path), so the
      LCP hero-bio text paints immediately instead of waiting on hydration.
@@ -330,6 +347,36 @@ html {
     z-index: -1;
   }
 
+  /* Editorial hero portrait: the <Image> keeps width/height=120 attributes
+     (jest/PW invariant) but is displayed larger on wide screens. Sizing is
+     done via CSS width/height on the img so layout space is reserved on the
+     page — transform-scale here would overflow into the social rail below. */
+  .hero-portrait img {
+    width: 120px;
+    height: 120px;
+  }
+
+  @media (min-width: 1024px) {
+    .hero-portrait img {
+      width: 160px;
+      height: 160px;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .hero-portrait img {
+      width: 200px;
+      height: 200px;
+    }
+  }
+
+  @media (min-width: 1536px) {
+    .hero-portrait img {
+      width: 240px;
+      height: 240px;
+    }
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .animated-background {
       animation: none;
@@ -426,21 +473,50 @@ html {
     opacity: 1;
   }
 
-  .modern-button {
-    background: linear-gradient(135deg, var(--color-primary-600) 0%, var(--color-violet-a) 100%);
+  /* Quiet text-link CTA: underline sweep on hover, no fill. Keeps the
+     gradient fingerprint for ONE action per section. */
+  .project-cta {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    color: var(--color-primary-600);
+    background: transparent;
     border: none;
-    color: white;
-    padding: 0.75rem 1.5rem;
-    border-radius: 12px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(79, 70, 229, 0.3);
+    padding: 0;
+    text-align: left;
+    position: relative;
+    transition: color 0.2s ease;
   }
 
-  .modern-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(79, 70, 229, 0.4);
-    background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-violet-b) 100%);
+  .dark .project-cta {
+    color: var(--color-primary-300);
+  }
+
+  .project-cta::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -3px;
+    height: 1.5px;
+    width: 100%;
+    background: linear-gradient(
+      90deg,
+      var(--color-primary-500),
+      var(--color-violet-a)
+    );
+    transform: scaleX(0.5);
+    transform-origin: left;
+    opacity: 0.6;
+    transition: transform 0.25s ease, opacity 0.25s ease;
+  }
+
+  .project-cta:hover::after {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+
+  .project-cta:hover {
+    color: var(--color-primary-500);
   }
 
   .tech-tag {
@@ -459,6 +535,19 @@ html {
     background: rgba(129, 140, 248, 0.08);
     border: 1px solid rgba(167, 139, 250, 0.22);
     color: var(--color-primary-300);
+  }
+
+  /* Tech tag variant for dark image overlays (on standard cards). */
+  .tag-overlay {
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.06em;
+    padding: 0.3rem 0.6rem;
+    border-radius: 6px;
+    color: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.12);
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    backdrop-filter: blur(6px);
   }
 
 /* On touch devices, keep scrolling but hide visual scrollbars to avoid

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import { FormEvent, memo, useCallback, useState } from 'react';
+import { BsGithub, BsLinkedin } from 'react-icons/bs';
 import { FaRegPaperPlane } from 'react-icons/fa';
+
+const LINKEDIN_URL = 'https://www.linkedin.com/in/yunior-profile/';
+const GITHUB_URL = 'https://github.com/batistaDev1113';
 
 const ContactForm = memo(() => {
   const [sending, setSending] = useState<boolean>(false);
@@ -117,91 +121,63 @@ const ContactForm = memo(() => {
       className='relative z-50 w-full max-w-7xl mx-auto my-16 px-4 scroll-mt-20'
       id='contact'
     >
-      <h1 className='w-full text-lg md:text-4xl font-semibold md:font-normal uppercase text-gray-900 dark:text-white opacity-70 text-center my-20 tracking-widest'>
-        Let&apos;s Connect
-      </h1>
+      <div className='flex flex-col items-center mb-16'>
+        <p className='eyebrow'>// 03 · Contact</p>
+        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+          Let&apos;s Connect
+        </h2>
+        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
+          Have a project in mind, a role to discuss, or just want to say hi?
+          The form goes straight to my inbox.
+        </p>
+      </div>
 
-      <div className='relative bg-white dark:bg-[#0c0f1e] rounded-2xl shadow-2xl overflow-hidden section-reveal'>
+      <div className='relative bg-white dark:bg-surface rounded-2xl shadow-2xl overflow-hidden section-reveal'>
         {/* Desktop Split Layout */}
         <div className='lg:grid lg:grid-cols-2 lg:min-h-150'>
-          {/* 3D Envelope Section */}
-          <section className='relative h-64 lg:h-full bg-linear-to-br from-[#1a0a4e] via-[#0d1a4e] to-[#0a0f2e] overflow-hidden flex items-center justify-center'>
-            {/* Animated Background Elements */}
-            <div className='absolute inset-0 opacity-20'>
-              <div
-                className='absolute top-12 left-12 w-4 h-4 bg-white/40 rounded-full animate-bounce'
-                style={{ animationDelay: '0s' }}
-              />
-              <div
-                className='absolute top-20 right-16 w-2 h-2 bg-white/60 rounded-full animate-bounce'
-                style={{ animationDelay: '1s' }}
-              />
-              <div
-                className='absolute bottom-16 left-20 w-3 h-3 bg-white/30 rounded-full animate-bounce'
-                style={{ animationDelay: '2s' }}
-              />
-              <div
-                className='absolute bottom-24 right-12 w-2 h-2 bg-white/50 rounded-full animate-bounce'
-                style={{ animationDelay: '1.5s' }}
-              />
-            </div>
+          {/* Contact Info Panel */}
+          <section className='relative p-8 lg:p-12 bg-linear-to-br from-primary-800 via-primary-700 to-violet-a dark:from-[#0b0e16] dark:via-[#111623] dark:to-[#0b0e16] overflow-hidden flex flex-col justify-center gap-6 natural'>
+            {/* Ambient glow */}
+            <div className='absolute -top-24 -right-24 w-72 h-72 rounded-full bg-violet-a/25 blur-3xl pointer-events-none' />
+            <div className='absolute -bottom-20 -left-16 w-64 h-64 rounded-full bg-primary-500/20 blur-3xl pointer-events-none' />
 
-            {/* 3D Envelope Container */}
-            <div className='relative transform-gpu perspective-1000'>
-              <div className='envelope-3d group cursor-pointer'>
-                {/* Envelope Back */}
-                <div className='envelope-back absolute w-32 h-24 lg:w-40 lg:h-32 bg-linear-to-br from-white via-gray-50 to-gray-100 dark:from-gray-100 dark:via-gray-200 dark:to-gray-300 rounded-lg shadow-2xl transform rotate-x-12 translate-y-2'></div>
+            <div className='relative'>
+              <p className='text-xs font-mono uppercase tracking-[0.18em] text-primary-200 dark:text-violet-a'>
+                Get in touch
+              </p>
+              <h3 className='fluid-subtitle text-2xl font-semibold mt-3 text-white leading-snug'>
+                Let&apos;s build something
+                <br />
+                worth talking about.
+              </h3>
+              <p className='mt-4 text-sm text-white/70 leading-6 max-w-sm'>
+                I&apos;m always open to discussing new projects, creative
+                ideas, or opportunities to be part of your vision.
+              </p>
 
-                {/* Envelope Main Body */}
-                <div className='envelope-body relative w-32 h-24 lg:w-40 lg:h-32 bg-linear-to-br from-white via-blue-50 to-purple-50 dark:from-gray-50 dark:via-blue-100 dark:to-purple-100 rounded-lg shadow-xl transform transition-all duration-500 group-hover:rotate-y-12 group-hover:translate-y-1'>
-                  {/* Envelope Flap */}
-                  <div className='envelope-flap absolute -top-2 left-0 right-0 h-12 lg:h-16 bg-linear-to-b from-blue-500 to-purple-600 transform rotate-x-45 origin-bottom rounded-t-lg shadow-lg group-hover:rotate-x-35 transition-all duration-500'>
-                    {/* Flap Highlight */}
-                    <div className='absolute inset-0 bg-linear-to-r from-white/20 via-transparent to-white/10 rounded-t-lg'></div>
-                  </div>
-
-                  {/* Email Icon Inside */}
-                  <div className='absolute inset-0 flex items-center justify-center'>
-                    <div className='w-8 h-8 lg:w-10 lg:h-10 bg-linear-to-r from-blue-500 to-purple-600 rounded-lg flex items-center justify-center shadow-lg transform group-hover:scale-110 transition-all duration-300'>
-                      <FaRegPaperPlane className='text-white text-sm lg:text-base transform group-hover:translate-x-1 transition-transform duration-300' />
-                    </div>
-                  </div>
-
-                  {/* Envelope Lines */}
-                  <div className='absolute bottom-4 left-4 right-4 space-y-1'>
-                    <div className='h-0.5 bg-linear-to-r from-gray-300 to-transparent rounded'></div>
-                    <div className='h-0.5 bg-linear-to-r from-gray-300 via-gray-200 to-transparent rounded w-3/4'></div>
-                    <div className='h-0.5 bg-linear-to-r from-gray-300 to-transparent rounded w-1/2'></div>
-                  </div>
-
-                  {/* Border Highlights */}
-                  <div className='absolute inset-0 rounded-lg bg-linear-to-br from-white/30 via-transparent to-transparent pointer-events-none'></div>
-                </div>
-
-                {/* Floating Message Dots */}
-                <div className='absolute -top-6 -right-6 lg:-top-8 lg:-right-8'>
-                  <div className='relative'>
-                    <div className='w-3 h-3 bg-linear-to-r from-green-400 to-blue-500 rounded-full animate-ping'></div>
-                    <div className='absolute inset-0 w-3 h-3 bg-linear-to-r from-green-400 to-blue-500 rounded-full animate-pulse'></div>
-                  </div>
-                </div>
-                <div className='absolute -top-3 -right-10 lg:-top-4 lg:-right-12'>
-                  <div
-                    className='w-2 h-2 bg-linear-to-r from-yellow-400 to-orange-500 rounded-full animate-pulse'
-                    style={{ animationDelay: '0.5s' }}
-                  ></div>
-                </div>
-                <div className='absolute -top-8 -right-2 lg:-top-10 lg:-right-3'>
-                  <div
-                    className='w-1.5 h-1.5 bg-linear-to-r from-pink-400 to-purple-500 rounded-full animate-pulse'
-                    style={{ animationDelay: '1s' }}
-                  ></div>
-                </div>
+              <div className='mt-8 flex flex-wrap gap-3'>
+                <a
+                  href={GITHUB_URL}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  aria-label='GitHub profile'
+                  className='inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white backdrop-blur-md transition-colors hover:bg-white/20'
+                >
+                  <BsGithub className='w-4 h-4' />
+                  GitHub
+                </a>
+                <a
+                  href={LINKEDIN_URL}
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  aria-label='LinkedIn profile'
+                  className='inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-4 py-2 text-sm font-medium text-white backdrop-blur-md transition-colors hover:bg-white/20'
+                >
+                  <BsLinkedin className='w-4 h-4' />
+                  LinkedIn
+                </a>
               </div>
             </div>
-
-            {/* Gradient Overlay */}
-            <div className='absolute inset-0 bg-linear-to-t from-black/10 via-transparent to-transparent pointer-events-none' />
           </section>
 
           {/* Form Section */}
@@ -254,9 +230,9 @@ const ContactForm = memo(() => {
                       }
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.fullName
-                          ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                          : 'border-gray-200 dark:border-gray-700 focus:border-blue-500 focus:ring-blue-500/20'
-                      } bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-gray-600`}
+? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
+                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border`}
                       placeholder='Enter your full name'
                     />
                     {errors.fullName && (
@@ -290,9 +266,9 @@ const ContactForm = memo(() => {
                       aria-describedby={errors.email ? emailErrorId : undefined}
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.email
-                          ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                          : 'border-gray-200 dark:border-gray-700 focus:border-blue-500 focus:ring-blue-500/20'
-                      } bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-gray-600`}
+? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
+                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border`}
                       placeholder='your.email@example.com'
                     />
                     {errors.email && (
@@ -329,9 +305,9 @@ const ContactForm = memo(() => {
                       placeholder='Tell me about your project or just say hello...'
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.message
-                          ? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                          : 'border-gray-200 dark:border-gray-700 focus:border-blue-500 focus:ring-blue-500/20'
-                      } bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-gray-600 resize-none`}
+? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
+                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border resize-none`}
                     />
                     {errors.message && (
                       <p
@@ -348,7 +324,7 @@ const ContactForm = memo(() => {
                   <button
                     type='submit'
                     disabled={sending}
-                    className='w-full bg-linear-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 hover:cursor-pointer text-white font-semibold py-4 px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-blue-500/50 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none shadow-lg hover:shadow-xl flex items-center justify-center gap-3'
+                    className='w-full bg-linear-to-r from-primary-600 to-violet-a hover:from-primary-500 hover:to-violet-b hover:cursor-pointer text-white font-semibold py-4 px-6 rounded-xl transition-all duration-200 transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-primary-400/50 disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none shadow-lg hover:shadow-xl flex items-center justify-center gap-3'
                   >
                     {sending ? (
                       <>

--- a/components/FooterComponent.tsx
+++ b/components/FooterComponent.tsx
@@ -2,25 +2,34 @@ import { BsGithub, BsLinkedin } from 'react-icons/bs';
 
 const LINKEDIN_URL = 'https://www.linkedin.com/in/yunior-profile/';
 const GITHUB_URL = 'https://github.com/batistaDev1113';
+const EMAIL = 'yuniorbatista1113@gmail.com';
 
 const YEAR = new Date().getFullYear();
 
 const FooterComponent = () => {
   return (
-    <footer className='relative mt-auto pt-0 rounded-t-none bg-transparent p-6 w-full'>
-      <div className='w-full'>
-        <hr className='my-6 border-gray-200 dark:border-gray-700 sm:mx-auto' />
-        <div className='w-full flex justify-between lg:justify-evenly md:text-center'>
-          <span className='text-sm text-gray-500 dark:text-gray-400'>
+    <footer className='relative mt-auto pt-12 pb-8 p-6 w-full'>
+      <div className='w-full max-w-7xl mx-auto'>
+        <hr className='mb-8 border-gray-200 dark:border-border sm:mx-auto' />
+        <div className='w-full flex flex-col items-center gap-6 sm:flex-row sm:justify-between'>
+          <span className='text-sm text-gray-500 dark:text-gray-400 font-mono'>
             &copy; {YEAR} Yunior Batista
           </span>
-          <div className='flex space-x-4 ml-8'>
+
+          <a
+            href={`mailto:${EMAIL}`}
+            className='text-sm text-gray-500 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-300 transition-colors font-mono'
+          >
+            {EMAIL}
+          </a>
+
+          <div className='flex space-x-4'>
             <a
               href={LINKEDIN_URL}
               target='_blank'
               rel='noopener noreferrer'
               aria-label="Link to Yunior's LinkedIn profile"
-              className='text-gray-500 hover:text-gray-900 dark:hover:text-white'
+              className='text-gray-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
             >
               <BsLinkedin className='h-5 w-5' />
             </a>
@@ -29,7 +38,7 @@ const FooterComponent = () => {
               target='_blank'
               rel='noopener noreferrer'
               aria-label="Link to Yunior's GitHub profile"
-              className='text-gray-500 hover:text-gray-900 dark:hover:text-white'
+              className='text-gray-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
             >
               <BsGithub className='h-5 w-5' />
             </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,6 +7,7 @@ import Image from 'next/image';
 import { memo, useEffect } from 'react';
 import { FaFileDownload } from 'react-icons/fa';
 import profile from '../public/picofme.webp';
+import SocialLinks from '../components/SocialLinks';
 
 const Hero = memo(() => {
   const HERO_ABOUT_TEXT = `Hi, I'm Yunior—a product-minded Senior Frontend Engineer. I turn complex ideas into intuitive, scalable web experiences with React, Next.js, and TypeScript, shipping accessible, high-performance interfaces that are as maintainable as they are polished.
@@ -38,97 +39,111 @@ I care about creating accessible, maintainable component systems that solve real
 
   return (
     <section
-      className='z-50 relative w-full min-h-screen md:h-screen flex justify-center md:items-center items-start py-6 md:py-0 animated-background'
+      className='z-50 relative w-full min-h-screen flex items-center animated-background'
       data-testid='hero-section'
     >
-      <div className='w-full flex justify-center md:items-center items-start py-2 md:py-0 hero-anim hero-anim-1'>
-        <div className='hero-card w-11/12 lg:w-10/12 xl:w-2/3 2xl:w-3/5 p-5 sm:p-6 md:p-10 lg:p-12 overflow-visible max-h-none relative'>
-          <div className='flex flex-col items-center text-center'>
-            <div className='hero-anim hero-anim-2'>
-              <div className='profile-image mb-6'>
-                <Image
-                  alt='Yunior Batista - Senior Frontend Engineer'
-                  height={120}
-                  src={profile}
-                  width={120}
-                  sizes='(max-width: 768px) 96px, 120px'
-                  className='rounded-full shadow-2xl'
-                  priority
-                  quality={90}
-                  placeholder='blur'
-                />
-              </div>
-            </div>
+      {/* Editorial grid: text left, portrait + meta right */}
+      <div className='w-full max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-12 gap-12 items-center px-4 sm:px-6 lg:px-8 py-20 md:py-16'>
+        {/* Left: headline + single primary CTA */}
+        <div className='lg:col-span-7 flex flex-col items-start text-left hero-anim hero-anim-1'>
+          <p className='eyebrow hero-anim hero-anim-2'>
+            &nbsp;// Senior Frontend Engineer
+          </p>
 
-            <p className='eyebrow mb-3 hero-anim hero-anim-2'>
-              // Hello, I&apos;m Yunior
-            </p>
+          <h1 className='mt-6 text-4xl sm:text-5xl md:text-6xl xl:text-7xl font-bold text-white drop-shadow-lg fluid-title hero-anim hero-anim-2 leading-[1.05] whitespace-nowrap'>
+            Yunior Batista
+          </h1>
 
-            <h1 className='mb-4 text-3xl font-bold text-white drop-shadow-lg fluid-title'>
-              Yunior Batista
-            </h1>
-
-            <div className='my-2 md:my-3 text-center w-full hero-anim hero-anim-3'>
-              <span
-                data-testid='hero-title'
-                className='text-transparent bg-linear-to-r from-blue-200 via-violet-200 to-indigo-200 bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
-              >
-                Senior Frontend Engineer
-              </span>
-            </div>
-
-            <p className='mt-1 text-sm sm:text-base text-white/70 font-mono hero-anim hero-anim-3'>
-              Building accessible, high-performance web experiences
-            </p>
-
-            <div className='w-full flex justify-center items-center hero-anim hero-anim-4'>
-              <p
-                data-testid='hero-bio'
-                className='w-full max-w-2xl mx-auto text-sm sm:text-base text-white/90 text-center leading-6 drop-shadow-sm backdrop-blur-md bg-black/20 rounded-lg p-3 sm:p-4 border border-white/20 whitespace-pre-line'
-              >
-                {HERO_ABOUT_TEXT}
-              </p>
-            </div>
-
-            <div className='mt-4 flex items-center gap-2 hero-anim hero-anim-4'>
-              <span className='relative flex h-2.5 w-2.5'>
-                <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75'></span>
-                <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400'></span>
-              </span>
-              <span className='text-sm text-white/70 font-mono'>
-                Available for new opportunities
-              </span>
-            </div>
-
-            <section className='grid w-full max-w-2xl grid-cols-1 md:grid-cols-2 gap-3 mt-3'>
-              <a
-                href='/resume'
-                aria-label='View Resume as HTML'
-                aria-describedby='resume-format-note'
-                className='button-about'
-              >
-                View Resume
-              </a>
-              <button
-                type='button'
-                aria-label='Download Resume'
-                aria-describedby='resume-format-note'
-                className='button-about hover:cursor-pointer'
-                onClick={handleDownloadResume}
-              >
-                Download Resume
-                <FaFileDownload className='ml-2' />
-              </button>
-            </section>
-            <p
-              id='resume-format-note'
-              className='mt-2 text-sm text-white/90 text-center max-w-2xl'
+          <div className='my-6 hero-anim hero-anim-3'>
+            <span
+              data-testid='hero-title'
+              className='text-transparent bg-linear-to-r from-blue-200 via-violet-200 to-indigo-200 bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
             >
-              View Resume opens the accessible HTML version. Use Download Resume
-              for the PDF file.
-            </p>
+              Senior Frontend Engineer
+            </span>
+          </div>
+
+          <p
+            data-testid='hero-bio'
+            className='w-full max-w-xl text-sm sm:text-base text-white/90 leading-6 drop-shadow-sm hero-anim hero-anim-4 whitespace-pre-line'
+          >
+            {HERO_ABOUT_TEXT}
+          </p>
+
+          <div className='mt-6 flex items-center gap-2 hero-anim hero-anim-4'>
+            <span className='relative flex h-2.5 w-2.5'>
+              <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75'></span>
+              <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400'></span>
+            </span>
+            <span className='text-sm text-white/70 font-mono'>
+              Available for new opportunities
+            </span>
+          </div>
+
+          {/* Single primary + quiet secondary CTA */}
+          <section
+            className='w-full flex flex-wrap items-center gap-4 mt-8'
+            aria-label='Resume actions'
+          >
+            <a
+              href='/resume'
+              aria-label='View Resume'
+              aria-describedby='resume-format-note'
+              className='button-about m-0'
+            >
+              View Resume
+            </a>
+            <button
+              type='button'
+              aria-label='Download Resume PDF'
+              aria-describedby='resume-format-note'
+              className='button-quiet hover:cursor-pointer'
+              onClick={handleDownloadResume}
+            >
+              <FaFileDownload className='mr-2' />
+              Resume PDF
+            </button>
+          </section>
+          <p
+            id='resume-format-note'
+            className='mt-4 text-sm text-white/70 text-left max-w-md'
+          >
+            HTML resume for screen readers; PDF for sharing.
+          </p>
+        </div>
+
+        {/* Right: portrait + meta rail */}
+        <div className='lg:col-span-5 flex lg:justify-end justify-center hero-anim hero-anim-2'>
+          <div className='flex flex-col items-center lg:items-end gap-10'>
+            <div className='hero-portrait profile-image'>
+              <Image
+                alt='Yunior Batista - Senior Frontend Engineer'
+                height={120}
+                src={profile}
+                width={120}
+                sizes='(max-width: 1024px) 120px, 220px'
+                className='rounded-full shadow-2xl object-cover'
+                priority
+                quality={90}
+                placeholder='blur'
+              />
+            </div>
+            <div className='flex lg:flex-col items-center gap-6 w-full'>
+              <SocialLinks
+                className='text-white/60 hover:text-white'
+                variant='icon'
+              />
+            </div>
           </div>
         </div>
+      </div>
+
+      {/* Scroll hint */}
+      <div className='absolute bottom-6 left-1/2 -translate-x-1/2 hidden md:flex flex-col items-center gap-2 text-white/40'>
+        <span className='font-mono text-[11px] tracking-widest uppercase'>
+          scroll
+        </span>
+        <span className='w-px h-8 bg-gradient-to-b from-white/40 to-transparent' />
       </div>
     </section>
   );

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,16 +2,16 @@
 
 // Using custom glassmorphism card instead of Flowbite.
 // Hero entrance animations are pure-CSS (@keyframes, see globals.css) so the
-// LCP bio text renders without requiring framer-motion to hydrate.
+// LCP hero-bio text renders without requiring framer-motion to hydrate.
 import Image from 'next/image';
 import { memo, useEffect } from 'react';
 import { FaFileDownload } from 'react-icons/fa';
 import profile from '../public/picofme.webp';
 
 const Hero = memo(() => {
-  const HERO_ABOUT_TEXT = `Hi, I'm Yunior—a product-minded Senior Frontend Engineer who turns complex ideas into intuitive, scalable digital experiences. I build modern web applications with React, Next.js, and TypeScript, bringing together strong UI/UX design, frontend architecture, and reliable product delivery.
+  const HERO_ABOUT_TEXT = `Hi, I'm Yunior—a product-minded Senior Frontend Engineer. I turn complex ideas into intuitive, scalable web experiences with React, Next.js, and TypeScript, shipping accessible, high-performance interfaces that are as maintainable as they are polished.
 
-I care about creating accessible, high-performance interfaces that are not only polished visually, but also maintainable and built to evolve. From reusable component systems to enterprise applications, I enjoy solving real product problems through thoughtful engineering and user-centered design.`;
+I care about creating accessible, maintainable component systems that solve real product problems through thoughtful engineering and user-centered design.`;
 
   useEffect(() => {
     // Preload resume PDF for faster access
@@ -42,8 +42,8 @@ I care about creating accessible, high-performance interfaces that are not only 
       data-testid='hero-section'
     >
       <div className='w-full flex justify-center md:items-center items-start py-2 md:py-0 hero-anim hero-anim-1'>
-        <div className='hero-card w-11/12 lg:w-10/12 xl:w-2/3 2xl:w-3/5 p-5 sm:p-6 md:p-10 lg:p-12 overflow-visible max-h-none'>
-          <div className='flex flex-col items-center'>
+        <div className='hero-card w-11/12 lg:w-10/12 xl:w-2/3 2xl:w-3/5 p-5 sm:p-6 md:p-10 lg:p-12 overflow-visible max-h-none relative'>
+          <div className='flex flex-col items-center text-center'>
             <div className='hero-anim hero-anim-2'>
               <div className='profile-image mb-6'>
                 <Image
@@ -59,17 +59,28 @@ I care about creating accessible, high-performance interfaces that are not only 
                 />
               </div>
             </div>
-            <h5 className='mb-2 text-3xl font-bold text-white drop-shadow-lg'>
+
+            <p className='eyebrow mb-3 hero-anim hero-anim-2'>
+              // Hello, I&apos;m Yunior
+            </p>
+
+            <h1 className='mb-4 text-3xl font-bold text-white drop-shadow-lg fluid-title'>
               Yunior Batista
-            </h5>
-            <div className='my-4 md:my-5 text-center w-full hero-anim hero-anim-3'>
+            </h1>
+
+            <div className='my-2 md:my-3 text-center w-full hero-anim hero-anim-3'>
               <span
                 data-testid='hero-title'
-                className='text-transparent bg-linear-to-r from-blue-200 via-purple-200 to-indigo-200 bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
+                className='text-transparent bg-linear-to-r from-blue-200 via-violet-200 to-indigo-200 bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
               >
                 Senior Frontend Engineer
               </span>
             </div>
+
+            <p className='mt-1 text-sm sm:text-base text-white/70 font-mono hero-anim hero-anim-3'>
+              Building accessible, high-performance web experiences
+            </p>
+
             <div className='w-full flex justify-center items-center hero-anim hero-anim-4'>
               <p
                 data-testid='hero-bio'
@@ -78,6 +89,17 @@ I care about creating accessible, high-performance interfaces that are not only 
                 {HERO_ABOUT_TEXT}
               </p>
             </div>
+
+            <div className='mt-4 flex items-center gap-2 hero-anim hero-anim-4'>
+              <span className='relative flex h-2.5 w-2.5'>
+                <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75'></span>
+                <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400'></span>
+              </span>
+              <span className='text-sm text-white/70 font-mono'>
+                Available for new opportunities
+              </span>
+            </div>
+
             <section className='grid w-full max-w-2xl grid-cols-1 md:grid-cols-2 gap-3 mt-3'>
               <a
                 href='/resume'

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -12,11 +12,11 @@ const Navigation = () => {
   };
 
   return (
-    <nav className='sticky top-0 z-100 w-full bg-white/90 dark:bg-[#07090f]/90 backdrop-blur-md border-b border-gray-200/40 dark:border-indigo-950/60 px-6 py-3 transition-all duration-300'>
+    <nav className='sticky top-0 z-100 w-full bg-white/90 dark:bg-night/90 backdrop-blur-md border-b border-gray-200/40 dark:border-border px-6 py-3 transition-all duration-300'>
       <div className='flex flex-wrap items-center justify-between'>
         <Link
           href='/'
-          className='self-center text-2xl font-semibold text-transparent bg-linear-to-r from-green-300 via-blue-500 to-purple-600 bg-clip-text md:text-4xl lg:text-3xl'
+          className='self-center text-2xl font-semibold text-transparent bg-linear-to-r from-primary-500 via-violet-a to-primary-400 bg-clip-text md:text-4xl lg:text-3xl font-display'
         >
           Yunior B.
         </Link>
@@ -68,12 +68,24 @@ const Navigation = () => {
           <ul className='mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-sm md:font-medium'>
             <li>
               <a
+                href='#skills'
+                aria-label='Skills and how I work'
+                onClick={handleNavLinkClick}
+                className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
+              >
+                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
+                  Skills
+                </span>
+              </a>
+            </li>
+            <li>
+              <a
                 href='#projects'
                 aria-label='Some projects I have built'
                 onClick={handleNavLinkClick}
                 className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
               >
-                <span className='pb-1 hover:text-teal-600 dark:hover:text-teal-300 hover:border-b-2 hover:border-indigo-500 hover:border-spacing-4'>
+                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
                   Some Projects I&apos;ve Built
                 </span>
               </a>
@@ -85,7 +97,7 @@ const Navigation = () => {
                 onClick={handleNavLinkClick}
                 className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
               >
-                <span className='pb-1 hover:text-teal-600 dark:hover:text-teal-300 hover:border-b-2 hover:border-indigo-500 hover:border-spacing-4'>
+                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
                   Contact Me
                 </span>
               </a>

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -1,7 +1,10 @@
 'use client';
-// Using custom glassmorphism cards and buttons
+// Image-forward project cards. Featured = wide split; standard = 4/3 portrait
+// with bottom gradient overlay (name + tech tags). Whole card opens the modal —
+// no separate footer button.
 import Image from 'next/image';
 import { lazy, memo, useState } from 'react';
+import { FaExternalLinkAlt } from 'react-icons/fa';
 
 // Lazy load modal for better performance
 const ProjectModal = lazy(() => import('./ProjectModal'));
@@ -17,6 +20,7 @@ export type ProjectProps = {
     liveDemoLink: string;
   };
 };
+
 const Project = memo(({ project, featured = false }: ProjectProps) => {
   const [openModal, setOpenModal] = useState(false);
   const {
@@ -28,19 +32,26 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
     liveDemoLink,
   } = project;
 
+  const openModalKey = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setOpenModal(true);
+    }
+  };
+
   return (
     <div className={featured ? 'w-full project-reveal' : 'project-reveal'}>
       {featured ? (
-        /* Featured: landscape on md+, stacked on mobile */
+        /* Featured: landscape split, image-led */
         <div
-          className='project-card w-full hover:cursor-pointer md:grid md:grid-cols-2 md:min-h-72 flex flex-col'
+          className='group project-card w-full hover:cursor-pointer md:grid md:grid-cols-12 md:min-h-72 flex flex-col'
           onClick={() => setOpenModal(true)}
           role='button'
           tabIndex={0}
-          onKeyDown={(e) => e.key === 'Enter' && setOpenModal(true)}
+          onKeyDown={openModalKey}
           aria-label={`View details for ${name}`}
         >
-          <div className='project-image-overlay h-56 md:h-full'>
+          <div className='project-image-overlay md:col-span-7 h-56 md:h-full'>
             <Image
               src={imageUrl || '/No-Image-Placeholder.svg'}
               width={800}
@@ -49,15 +60,13 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
               className='w-full h-full object-cover'
               loading='eager'
               priority
-              sizes='(max-width: 768px) 100vw, 50vw'
+              sizes='(max-width: 768px) 100vw, 58vw'
               quality={80}
             />
           </div>
-          <div className='p-8 flex flex-col justify-center gap-4'>
-            <span className='text-xs font-semibold uppercase tracking-widest text-indigo-400'>
-              Featured Project
-            </span>
-            <h4 className='text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-white'>
+          <div className='md:col-span-5 p-8 flex flex-col justify-center gap-4 relative'>
+            <span className='eyebrow'>// Featured</span>
+            <h4 className='fluid-subtitle text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-white'>
               {name}
             </h4>
             <p className='text-gray-700 dark:text-gray-300 text-sm leading-relaxed line-clamp-4'>
@@ -70,66 +79,56 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
                 </span>
               ))}
             </div>
-            <button
-              onClick={(e) => {
-                e.stopPropagation();
-                setOpenModal(true);
-              }}
-              className='modern-button w-fit mt-2 hover:cursor-pointer px-8'
-            >
-              View Details
-            </button>
+            <div className='flex items-center gap-4 mt-2'>
+              <span className='project-cta'>Open case study</span>
+              <FaExternalLinkAlt className='w-3.5 h-3.5 text-primary-500' />
+            </div>
           </div>
         </div>
       ) : (
-        /* Standard card */
-        <div className='w-full max-w-sm hover:cursor-pointer h-full flex flex-col'>
-          <div
-            className='project-card w-full h-full flex flex-col'
-            onClick={() => setOpenModal(true)}
-            role='button'
-            tabIndex={0}
-            onKeyDown={(e) => e.key === 'Enter' && setOpenModal(true)}
-            aria-label={`View details for ${name}`}
-          >
-            <div className='project-image-overlay shrink-0'>
-              <Image
-                src={imageUrl || '/No-Image-Placeholder.svg'}
-                width={400}
-                height={250}
-                alt={`${name} project screenshot`}
-                className='w-full object-cover h-48'
-                loading='lazy'
-                sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
-                quality={75}
-              />
+        /* Standard: 4/3 portrait, gradient overlay caption */
+        <div
+          className='group project-card relative w-full aspect-[4/3] hover:cursor-pointer overflow-hidden rounded-2xl'
+          onClick={() => setOpenModal(true)}
+          role='button'
+          tabIndex={0}
+          onKeyDown={openModalKey}
+          aria-label={`View details for ${name}`}
+          data-project-card
+        >
+          <div className='project-image-overlay absolute inset-0'>
+            <Image
+              src={imageUrl || '/No-Image-Placeholder.svg'}
+              width={400}
+              height={300}
+              alt={`${name} project screenshot`}
+              className='w-full h-full object-cover'
+              loading='lazy'
+              sizes='(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw'
+              quality={75}
+            />
+          </div>
+
+          {/* Bottom gradient + caption */}
+          <div className='absolute inset-x-0 bottom-0 p-5 pt-16 bg-linear-to-t from-black/85 via-black/45 to-transparent'>
+            <h4 className='text-lg font-bold tracking-tight text-white drop-shadow line-clamp-2'>
+              {name}
+            </h4>
+            <div className='mt-2 flex flex-wrap gap-2'>
+              {technologies.slice(0, 3).map((tech, index) => (
+                <span
+                  key={index}
+                  className='tag-overlay'
+                >
+                  {tech}
+                </span>
+              ))}
             </div>
-            <div className='p-6 flex flex-col flex-1'>
-              <div className='flex-1 space-y-3'>
-                <h4 className='text-xl font-bold tracking-tight text-gray-900 dark:text-white line-clamp-2'>
-                  {name}
-                </h4>
-                <p className='font-normal text-gray-700 dark:text-gray-300 text-sm line-clamp-3 leading-relaxed'>
-                  {description}
-                </p>
-                <div className='flex flex-wrap gap-2 min-h-8 items-start'>
-                  {technologies.slice(0, 3).map((tech, index) => (
-                    <span key={index} className='tech-tag'>
-                      {tech}
-                    </span>
-                  ))}
-                </div>
-              </div>
-              <button
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setOpenModal(true);
-                }}
-                className='modern-button w-full shrink-0 mt-4 hover:cursor-pointer'
-              >
-                View Details
-              </button>
-            </div>
+          </div>
+
+          {/* Corner glyph */}
+          <div className='absolute top-4 right-4 w-9 h-9 rounded-full bg-white/10 backdrop-blur-md border border-white/20 flex items-center justify-center text-white opacity-0 group-hover:opacity-100 transition-opacity duration-300'>
+            <FaExternalLinkAlt className='w-4 h-4' />
           </div>
         </div>
       )}
@@ -138,6 +137,8 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
         <ProjectModal
           openModal={openModal}
           setOpenModal={setOpenModal}
+          name={name}
+          description={description}
           technologies={technologies}
           githubLink={githubLink}
           liveDemoLink={liveDemoLink}

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -84,7 +84,14 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
       ) : (
         /* Standard card */
         <div className='w-full max-w-sm hover:cursor-pointer h-full flex flex-col'>
-          <div className='project-card w-full h-full flex flex-col'>
+          <div
+            className='project-card w-full h-full flex flex-col'
+            onClick={() => setOpenModal(true)}
+            role='button'
+            tabIndex={0}
+            onKeyDown={(e) => e.key === 'Enter' && setOpenModal(true)}
+            aria-label={`View details for ${name}`}
+          >
             <div className='project-image-overlay shrink-0'>
               <Image
                 src={imageUrl || '/No-Image-Placeholder.svg'}
@@ -114,7 +121,10 @@ const Project = memo(({ project, featured = false }: ProjectProps) => {
                 </div>
               </div>
               <button
-                onClick={() => setOpenModal(!openModal)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpenModal(true);
+                }}
                 className='modern-button w-full shrink-0 mt-4 hover:cursor-pointer'
               >
                 View Details

--- a/components/ProjectModal.tsx
+++ b/components/ProjectModal.tsx
@@ -68,7 +68,7 @@ const ProjectModal = memo(
         />
 
         {/* Modal */}
-        <div className='relative bg-white dark:bg-gray-800 rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden glassmorphism-modal'>
+        <div className='relative bg-white dark:bg-surface border border-gray-100 dark:border-border rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden'>
           {/* Header */}
           <div className='flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700'>
             <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>

--- a/components/ProjectModal.tsx
+++ b/components/ProjectModal.tsx
@@ -6,6 +6,8 @@ import { FaExternalLinkAlt, FaGithub, FaTimes } from 'react-icons/fa';
 
 type ProjectModalProps = {
   openModal: boolean;
+  name: string;
+  description: string;
   technologies: string[];
   githubLink: string;
   liveDemoLink: string;
@@ -16,6 +18,8 @@ const ProjectModal = memo(
   ({
     openModal,
     setOpenModal,
+    name,
+    description,
     technologies,
     githubLink,
     liveDemoLink,
@@ -71,8 +75,8 @@ const ProjectModal = memo(
         <div className='relative bg-white dark:bg-surface border border-gray-100 dark:border-border rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] overflow-hidden'>
           {/* Header */}
           <div className='flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700'>
-            <h2 className='text-2xl font-bold text-gray-900 dark:text-white'>
-              Project Technologies
+            <h2 className='fluid-subtitle text-2xl font-bold text-gray-900 dark:text-white'>
+              {name}
             </h2>
             <button
               onClick={() => setOpenModal(false)}
@@ -85,6 +89,13 @@ const ProjectModal = memo(
 
           {/* Body */}
           <div className='p-6 space-y-6 overflow-y-auto max-h-[calc(90vh-140px)]'>
+            {/* Description Section */}
+            <div>
+              <p className='text-gray-600 dark:text-gray-300 text-sm leading-relaxed'>
+                {description}
+              </p>
+            </div>
+
             {/* Technologies Section */}
             <div>
               <h3 className='text-lg font-semibold text-gray-900 dark:text-white mb-4'>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -32,16 +32,16 @@ const Projects = async () => {
         </p>
       </div>
 
-      {/* Featured project — full-width landscape card */}
+      {/* Featured project — full-width cinematic card */}
       {featured && (
-        <div className='mb-8'>
+        <div className='mb-10'>
           <Project project={featured} featured />
         </div>
       )}
 
-      {/* Remaining projects — 2-col on md, 3-col on lg */}
+      {/* Remaining projects — responsive 1/2/3-col, generic for any N */}
       {rest.length > 0 && (
-        <div className='grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 justify-items-center items-stretch'>
+        <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 justify-items-center items-stretch'>
           {rest.map((project) => (
             <Project key={project.id} project={project} />
           ))}

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -21,9 +21,16 @@ const Projects = async () => {
       className='w-full max-w-7xl mx-auto my-20 px-4 z-50 scroll-mt-20'
       id='projects'
     >
-      <h3 className='w-full text-lg md:text-4xl font-semibold md:font-normal uppercase text-gray-900 dark:text-white opacity-70 text-center mb-16 tracking-widest'>
-        Some Projects I&apos;ve Built
-      </h3>
+      <div className='flex flex-col items-center mb-16'>
+        <p className='eyebrow'>// 02 · Work</p>
+        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+          Selected Projects
+        </h2>
+        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
+          A few things I&apos;ve designed and built. Click any card to see the
+          tech stack and live links.
+        </p>
+      </div>
 
       {/* Featured project — full-width landscape card */}
       {featured && (

--- a/components/SocialLinks.tsx
+++ b/components/SocialLinks.tsx
@@ -1,0 +1,54 @@
+import { BsGithub, BsLinkedin, BsEnvelopeOpenFill } from 'react-icons/bs';
+
+const LINKEDIN_URL = 'https://www.linkedin.com/in/yunior-profile/';
+const GITHUB_URL = 'https://github.com/batistaDev1113';
+const EMAIL = 'yuniorbatista1113@gmail.com';
+
+type SocialLinksProps = {
+  className?: string;
+  variant?: 'icon' | 'text';
+};
+
+const ITEMS = [
+  {
+    label: 'GitHub',
+    href: GITHUB_URL,
+    Icon: BsGithub,
+  },
+  {
+    label: 'LinkedIn',
+    href: LINKEDIN_URL,
+    Icon: BsLinkedin,
+  },
+  {
+    label: 'Email',
+    href: `mailto:${EMAIL}`,
+    Icon: BsEnvelopeOpenFill,
+  },
+];
+
+const SocialLinks = ({ className = '', variant = 'icon' }: SocialLinksProps) => {
+  return (
+    <div
+      className={`flex gap-6 ${variant === 'text' ? 'flex-col items-start' : 'flex-row items-center'}`}
+    >
+      {ITEMS.map(({ label, href, Icon }) => (
+        <a
+          key={label}
+          href={href}
+          target={href.startsWith('http') ? '_blank' : undefined}
+          rel={href.startsWith('http') ? 'noopener noreferrer' : undefined}
+          aria-label={`${label} profile`}
+          className={`group flex items-center gap-2 transition-colors duration-200 ${className}`}
+        >
+          <Icon className='w-5 h-5 transition-transform duration-200 group-hover:scale-110' />
+          {variant === 'text' && (
+            <span className='text-sm font-mono'>{label}</span>
+          )}
+        </a>
+      ))}
+    </div>
+  );
+};
+
+export default SocialLinks;

--- a/components/Toolbox.tsx
+++ b/components/Toolbox.tsx
@@ -1,0 +1,111 @@
+// Static skills strip + toolbox marquee. Pure CSS motion (no JS), so it
+// renders server-side with zero client JS on the critical path.
+import {
+  FaAccessibleIcon,
+  FaCode,
+  FaReact,
+  FaMobileAlt,
+} from 'react-icons/fa';
+
+const TOOLBOX = [
+  'React',
+  'Next.js',
+  'TypeScript',
+  'JavaScript',
+  'Tailwind CSS',
+  'Redux',
+  'React Query',
+  'Zustand',
+  'Node.js',
+  'Playwright',
+  'Jest',
+  'Storybook',
+  'HTML',
+  'CSS',
+  'Accessibility (a11y)',
+  'Git',
+  'CI / CD',
+  'Vercel',
+];
+
+const SKILLS = [
+  {
+    title: 'Frontend Architecture',
+    description:
+      'Scalable React and Next.js apps with component systems, typed contracts, and clean data layers that stay maintainable as they grow.',
+    icon: FaReact,
+  },
+  {
+    title: 'Accessibility & Standards',
+    description:
+      'WCAG-minded interfaces — semantic HTML, robust focus management, and CSS-first animations that respect reduced-motion preferences.',
+    icon: FaAccessibleIcon,
+  },
+  {
+    title: 'Performance & Delivery',
+    description:
+      'Core Web Vitals as a first-class concern: lazy loading, code-splitting, and measured Lighthouse budgets shipped through CI.',
+    icon: FaCode,
+  },
+  {
+    title: 'Quality Tooling',
+    description:
+      'TypeScript strictness, unit + end-to-end coverage with Jest and Playwright, and a CI pipeline that reviews every PR before it lands.',
+    icon: FaMobileAlt,
+  },
+];
+
+const Toolbox = () => {
+  return (
+    <section
+      id='skills'
+      className='w-full max-w-7xl mx-auto my-24 px-4 scroll-mt-20 relative z-50'
+      aria-label='Skills and toolbox'
+    >
+      <div className='flex flex-col items-center mb-16'>
+        <p className='eyebrow'>// 01 · Skills</p>
+        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+          How I build
+        </h2>
+        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
+          A practical toolkit for shipping reliable, human-first web products —
+          from architecture and accessibility through performance and delivery.
+        </p>
+      </div>
+
+      {/* Skill cards */}
+      <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6'>
+        {SKILLS.map((skill) => (
+          <div
+            key={skill.title}
+            className='card-elevated rounded-2xl p-6 relative overflow-hidden group transition-transform duration-300 hover:-translate-y-1.5'
+          >
+            <div className='w-11 h-11 rounded-xl bg-linear-to-br from-primary-600 to-violet-a flex items-center justify-center mb-5 text-white shadow-lg shadow-primary-500/20'>
+              <skill.icon className='w-5 h-5' />
+            </div>
+            <h3 className='fluid-subtitle text-base font-semibold text-gray-900 dark:text-white'>
+              {skill.title}
+            </h3>
+            <p className='mt-2 text-sm text-gray-600 dark:text-gray-400 leading-6'>
+              {skill.description}
+            </p>
+          </div>
+        ))}
+      </div>
+
+      {/* Toolbox rail — natively scrollable so every tool is reachable */}
+      <div className='mt-16'>
+        <p className='eyebrow mb-6 text-center'>// Toolbox</p>
+        <div className='toolbox-rail' role='list'>
+          {TOOLBOX.map((tool, i) => (
+            <span key={i} className='toolbox-item' role='listitem'>
+              {tool}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default Toolbox;


### PR DESCRIPTION
## Summary

- Editorial hero: single-line name (whitespace-nowrap), portrait sizing via CSS width/height (120->240px across breakpoints) instead of transform-scale so it never overflows, centered social rail, normalized social icon sizes (BsEnvelopeOpenFill matches GitHub/LinkedIn glyph height zero-console-error regressions).
- Generic bento + grid projects: featured full-width cinematic split card + image-forward 4:3 overlay tiles; responsive 1/2/3-col grid scales to any N projects; modal retitled to project name with description-led content.
