### PR TITLE
fix(ui): remove stray mobile card overlay under contact social pills

### DIFF
--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -22,7 +22,7 @@ const BackToTop = () => {
       type='button'
       onClick={scrollToTop}
       aria-label='Back to top'
-      className='inline-flex items-center gap-2 text-sm text-gray-500 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-300 transition-colors font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 rounded px-2 py-1'
+      className='inline-flex items-center gap-2 text-sm text-gray-500 hover:text-primary-600 hover:cursor-pointer dark:text-gray-400 dark:hover:text-primary-300 transition-colors font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 rounded px-2 py-1'
     >
       <FaArrowUp className='h-3.5 w-3.5' aria-hidden='true' />
       Back to top

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -185,9 +185,6 @@ const ContactForm = memo(() => {
             aria-label='Contact Form'
             className='relative flex items-center justify-center p-8 lg:p-12'
           >
-            {/* Mobile Card Overlay Effect */}
-            <div className='absolute -top-8 left-8 right-8 lg:hidden bg-white/10 dark:bg-gray-900/10 backdrop-blur-sm rounded-t-2xl h-8' />
-
             {sending ? (
               <div className='flex flex-col items-center justify-center w-full text-center pop-in'>
                 <div className='w-20 h-20 bg-linear-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center mb-6'>


### PR DESCRIPTION
## Fix stray mobile card overlay under contact social pills

On mobile (e.g. iPhone 16 Pro Max, light mode) a faint "card" appeared right below the GitHub/LinkedIn pills on the contact form.

### Cause
The decorative `Mobile Card Overlay Effect` div was absolutely positioned `-top-8` inside the form section, so it was pulled 32px up out of the form `<main>` and straddled the seam with the info panel — right under the social pills. In light mode `bg-white/10` + `backdrop-blur-sm` read as a stray white card.

### Fix
Removed the overlay entirely (purely decorative, no content). Verified at 430×932 mobile viewport, light + dark:
- Overlay element no longer present
- Geometry now clean: pills bottom 554 / info panel bottom 586 / form main top 586 (no overlap)

### Gates
tsc clean, jest 14/14, prettier (no new drift), `next build` green, Playwright e2e green.
