### PR TITLE
feat(hero): orbit command-ring with tech chips + status dot

### DIFF
--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -330,9 +330,85 @@ html {
     left: -3px;
     right: -3px;
     bottom: -3px;
-    background: linear-gradient(45deg, var(--color-primary-500), var(--color-violet-a), var(--color-primary-600));
+    /* Concept A command-ring: static conic gradient (brand indigo→violet).
+       Static by design — animating background/background-position on the
+       ring would re-trigger the paint stall that PR #139 eliminated. */
+    background: conic-gradient(
+      from 210deg,
+      var(--color-primary-500),
+      var(--color-violet-a),
+      var(--color-violet-b),
+      var(--color-primary-600),
+      var(--color-primary-500)
+    );
     border-radius: 50%;
     z-index: -1;
+  }
+
+  /* Orbit / command-ring chips. The container rotates on the compositor
+     (transform-only, per the PR #139 paint-stall constraint) and each chip
+     counter-rotates so its label stays upright. Chips are anchored to the
+     edge midpoints of the square container, so their anchor traces the same
+     radius as the avatar's circumference — i.e. they orbit on the ring. */
+  .orbit-spin {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    will-change: transform;
+    animation: orbitSpin 24s linear infinite;
+  }
+
+  .orbit-chip {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    white-space: nowrap;
+    animation: orbitCounterSpin 24s linear infinite;
+  }
+
+  .orbit-chip-1 {
+    top: 0;
+    left: 50%;
+  }
+
+  .orbit-chip-2 {
+    top: 50%;
+    right: 0;
+  }
+
+  .orbit-chip-3 {
+    bottom: 0;
+    left: 50%;
+  }
+
+  @keyframes orbitSpin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @keyframes orbitCounterSpin {
+    from {
+      transform: translate(-50%, -50%) rotate(360deg);
+    }
+    to {
+      transform: translate(-50%, -50%) rotate(0deg);
+    }
+  }
+
+  /* Status ping dot anchored on the command ring (45 deg). */
+  .orbit-ping-dot {
+    position: absolute;
+    top: 14%;
+    right: 14%;
+    width: 10px;
+    height: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
   }
 
   /* Editorial hero portrait: the <Image> keeps width/height=120 attributes
@@ -399,6 +475,11 @@ html {
       animation: none;
       transition: none;
       transform: none;
+    }
+
+    .orbit-spin,
+    .orbit-chip {
+      animation: none;
     }
   }
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -120,6 +120,21 @@ I care about creating accessible, maintainable component systems that solve real
                 quality={80}
                 placeholder='blur'
               />
+              <div className='orbit-spin' aria-hidden='true'>
+                <span className='orbit-chip orbit-chip-1 rounded-full border border-white/15 bg-slate-900/75 px-2.5 py-1 font-mono text-[10px] text-white/90 shadow-lg sm:text-xs'>
+                  React
+                </span>
+                <span className='orbit-chip orbit-chip-2 rounded-full border border-white/15 bg-slate-900/75 px-2.5 py-1 font-mono text-[10px] text-white/90 shadow-lg sm:text-xs'>
+                  Next.js
+                </span>
+                <span className='orbit-chip orbit-chip-3 rounded-full border border-white/15 bg-slate-900/75 px-2.5 py-1 font-mono text-[10px] text-white/90 shadow-lg sm:text-xs'>
+                  TypeScript
+                </span>
+              </div>
+              <span className='orbit-ping-dot' aria-hidden='true'>
+                <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75'></span>
+                <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400'></span>
+              </span>
             </div>
             <div className='flex lg:flex-col items-center gap-6 w-full'>
               <SocialLinks


### PR DESCRIPTION
Implements the chosen hero-image concept **A — Orbit / command-ring**:

- Static **conic gradient** command-ring (brand indigo → violet) around the circular avatar, replacing the old linear-gradient ring. Static by design — animating background-position on the ring would re-trigger the PR #139 paint stall.
- Three floating tech chips (**React, Next.js, TypeScript**) orbiting the ring on a slow compositor-only `transform: rotate()` (24s). Each chip counter-rotates so its label stays upright. Chip anchors are edge midpoints of the square container, so their path traces the avatar's exact radius.
- A **status ping dot** (emerald, Tailwind `animate-ping`) anchored on the ring at 45°.
- All motion is `transform`/`opacity`-only (per the PR #139 compositor constraint); no framer-motion; decorative elements are `aria-hidden`; `prefers-reduced-motion` disables all orbit animation (verified).

## Verification

- `tsc --noEmit` clean
- Jest 14/14 (`npx jest --watchAll=false --runInBand`)
- `next build` green
- Playwright e2e green (hero bio + title regression net, zero console errors)
- Prettier: `components/Hero.tsx` clean; `globals.css` unchanged drift pattern (4-space indent, pre-existing, no CI gate)
- Runtime assertions (1440x900 + 430x932, light + dark): conic-gradient ring applied, `orbitSpin`/`orbitCounterSpin` active, chip orbit motion confirmed, no horizontal scrollbar overflow
- Reduced-motion emulation: `animation: none` on all orbit elements
