### PR TITLE
feat(hero): squircle photo treatment with glow + offset ring

### DIFF
--- a/__tests__/Hero.test.js
+++ b/__tests__/Hero.test.js
@@ -62,6 +62,6 @@ describe('Hero', () => {
     expect(heroImage).toBeInTheDocument();
     expect(heroImage).toHaveAttribute('width', '120');
     expect(heroImage).toHaveAttribute('height', '120');
-    expect(heroImage).toHaveClass('rounded-full');
+    expect(heroImage).toHaveClass('hero-photo');
   });
 });

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -318,28 +318,76 @@ html {
     background-position: 50% 50%;
   }
 
-  /* Profile Image Enhancements */
+  /* Hero Photo Treatment: squircle photo + soft blurred glow + offset
+     accent ring. The photo is a squircle (border-radius ~30%); a blurred
+     radial glow in the brand violet/indigo sits behind it (larger than the
+     photo), and a border-only accent ring (same squircle radius, slightly
+     larger, translated + rotated ~6deg) settles into place on load via a
+     pure-CSS @keyframes animation. All motion is transform/opacity-only
+     (per the PR #139 paint-stall constraint) and both decorations are
+     aria-hidden. */
   .profile-image {
     position: relative;
+    isolation: isolate;
   }
 
-  .profile-image::before {
-    content: '';
+  .hero-glow {
     position: absolute;
-    top: -3px;
-    left: -3px;
-    right: -3px;
-    bottom: -3px;
-    background: linear-gradient(45deg, var(--color-primary-500), var(--color-violet-a), var(--color-primary-600));
+    inset: -35%;
     border-radius: 50%;
+    background: radial-gradient(
+      circle,
+      color-mix(in srgb, var(--color-violet-b) 45%, transparent) 0%,
+      color-mix(in srgb, var(--color-primary-500) 22%, transparent) 45%,
+      transparent 70%
+    );
+    filter: blur(48px);
     z-index: -1;
+    pointer-events: none;
+    animation: glowPulse 5s ease-in-out infinite;
+  }
+
+  .hero-ring {
+    position: absolute;
+    inset: -8px;
+    border: 2px solid var(--color-violet-a);
+    border-radius: 30%;
+    pointer-events: none;
+    transform: translate(10px, 6px) rotate(6deg);
+    animation: ringSettle 0.9s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  }
+
+  @keyframes glowPulse {
+    0%,
+    100% {
+      transform: scale(1);
+      opacity: 0.7;
+    }
+    50% {
+      transform: scale(1.1);
+      opacity: 1;
+    }
+  }
+
+  @keyframes ringSettle {
+    from {
+      transform: translate(0, 0) rotate(0deg);
+      opacity: 0;
+    }
+    to {
+      transform: translate(10px, 6px) rotate(6deg);
+      opacity: 1;
+    }
   }
 
   /* Editorial hero portrait: the <Image> keeps width/height=120 attributes
      (jest/PW invariant) but is displayed larger on wide screens. Sizing is
      done via CSS width/height on the img so layout space is reserved on the
-     page — transform-scale here would overflow into the social rail below. */
+     page — transform-scale here would overflow into the social rail below.
+     The squircle radius lives in CSS (the img class in Hero.tsx carries no
+     radius utility) so the offset ring can share the same border-radius. */
   .hero-portrait img {
+    border-radius: 30%;
     width: 120px;
     height: 120px;
   }
@@ -394,11 +442,15 @@ html {
     }
 
     .profile-image,
-    .profile-image::before,
     .profile-image:hover {
       animation: none;
       transition: none;
       transform: none;
+    }
+
+    .hero-glow,
+    .hero-ring {
+      animation: none;
     }
   }
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -109,13 +109,15 @@ I care about creating accessible, maintainable component systems that solve real
         <div className='lg:col-span-5 flex lg:justify-end justify-center hero-anim hero-anim-2'>
           <div className='flex flex-col items-center lg:items-end gap-10'>
             <div className='hero-portrait profile-image'>
+              <span className='hero-glow' aria-hidden='true' />
+              <span className='hero-ring' aria-hidden='true' />
               <Image
                 alt='Yunior Batista - Senior Frontend Engineer'
                 height={120}
                 src={portraitSrc}
                 width={120}
                 sizes='(max-width: 1023px) 120px, (max-width: 1279px) 160px, (max-width: 1535px) 200px, 240px'
-                className='rounded-full shadow-2xl object-cover'
+                className='hero-photo shadow-2xl object-cover'
                 priority
                 quality={80}
                 placeholder='blur'


### PR DESCRIPTION
Replaces the circular photo treatment with the new **squircle + glow + offset ring** spec:

- **Squircle photo** — `border-radius: 30%` (moved from the `rounded-full` utility into CSS on `.hero-portrait img`, so the ring shares the exact same radius). A semantic `hero-photo` class hooks the portrait for the jest invariant (test updated from `rounded-full`).
- **Soft glow** — `.hero-glow`: blurred (`blur(48px)`) radial gradient in brand violet/indigo, `inset: -35%` so it's ~1.7× the photo, centered behind it, `aria-hidden`, `pointer-events: none`.
- **Offset accent ring** — `.hero-ring`: border-only (`2px solid --color-violet-a`, no fill) squircle at the same 30% radius, `inset: -8px` + `translate(10px, 6px) rotate(6deg)`, painted behind the photo (DOM order + `isolation: isolate` on the wrapper).
- **Settle-in animation** — pure-CSS `@keyframes ringSettle` (0.9s, back-out easing) animates the ring from neutral into its rotated position.
- **Glow pulse** — `@keyframes glowPulse` (5s ease-in-out, scale 1→1.1 + opacity 0.7→1); both animations are transform/opacity-only per the PR #139 paint-stall constraint, and `prefers-reduced-motion` disables them (ring holds its settled position).

## Verification

- `tsc --noEmit` clean
- Jest 14/14 (`npx jest --watchAll=false --runInBand`)
- `next build` green
- Playwright e2e green (hero regression net, zero console errors)
- Prettier clean on changed files
- Runtime computed-style assertions (1440×900 + 430×932): 30/30 checks pass — squircle radius, radial-blur glow centered & larger, ring `matrix(...)` matches rotate(6deg)+translate(10,6), empty ring fill, both keyframe animations active, no horizontal overflow, reduced-motion kills both animations while keeping the ring rotated
