### PR TITLE
fix(ui): hero light-mode gradient flash + scroll-aware sticky nav

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,21 +16,31 @@ export default function Home() {
       tabIndex={-1}
       className='flex min-h-screen flex-col items-center w-full scroll-smooth dark:bg-night'
     >
-      <Navigation />
       <ScrollToHash />
       <ScrollReveal />
+      {/* Full-page wrapper: the nav is sticky within it, so it stays pinned
+          for the whole scroll. At the top of the page it is transparent and
+          sits over the (dark, in both themes) hero; once scrolled it frosts
+          to the theme surface. */}
       <div className='relative w-full'>
-        <Hero />
-        {/* Curved seam: the light content below "dips" up into the dark hero */}
-        <div
-          aria-hidden='true'
-          className='relative z-40 -mt-16 sm:-mt-20 lg:-mt-24 h-16 sm:h-20 lg:h-24 bg-light-surface dark:bg-night rounded-t-[100%] pointer-events-none'
-        />
+        <Navigation />
+        {/* First viewport: hero pulled up so it sits behind the nav strip
+            (nav is transparent at the top and shares the hero surface) */}
+        <div className='relative w-full -mt-16 min-h-[calc(100vh+4rem)]'>
+          <div className='absolute inset-0 z-50'>
+            <Hero />
+          </div>
+          {/* Curved seam: the light content below "dips" up into the dark hero */}
+          <div
+            aria-hidden='true'
+            className='absolute bottom-0 inset-x-0 z-40 h-16 sm:h-20 lg:h-24 bg-light-surface dark:bg-night rounded-t-[100%] pointer-events-none'
+          />
+        </div>
+        <Toolbox />
+        <Projects />
+        <ContactForm />
+        <FooterComponent />
       </div>
-      <Toolbox />
-      <Projects />
-      <ContactForm />
-      <FooterComponent />
     </main>
   );
 }

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -318,6 +318,16 @@ html {
     background-position: 50% 50%;
   }
 
+  /* Light mode: the 300% crop exposes two adjacent translucent rgba stops whose
+     bright wash bands composite over the white page surface, painting a hard
+     diagonal "flash" line toward the bottom-right corner. A 500% crop shows a
+     single smooth sweep between the same stops — the flash collapses while the
+     gradient framing is retained. Dark mode renders those stops over near-black
+     already, so it keeps the 300% framing. */
+  .light .animated-background {
+    background-size: 500% 500%;
+  }
+
   /* Profile Image Enhancements */
   .profile-image {
     position: relative;

--- a/components/ModeToggle.tsx
+++ b/components/ModeToggle.tsx
@@ -6,7 +6,7 @@ import { BsMoonFill, BsSunFill } from 'react-icons/bs';
 
 const emptySubscribe = () => () => {};
 
-export function ModeToggle() {
+export function ModeToggle({ onHero = false }: { onHero?: boolean }) {
   const mounted = useSyncExternalStore(
     emptySubscribe,
     () => true,
@@ -33,7 +33,10 @@ export function ModeToggle() {
       {isDarkMode ? (
         <BsSunFill size={15} className='text-white' />
       ) : (
-        <BsMoonFill className='text-black' size={15} />
+        <BsMoonFill
+          className={onHero ? 'text-white' : 'text-black'}
+          size={15}
+        />
       )}
     </button>
   );

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,18 +1,41 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ModeToggle } from './ModeToggle';
 
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 24);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   const handleNavLinkClick = () => {
     setIsOpen(false);
   };
 
+  // At the top of the page the nav sits over the (dark, in both themes) hero,
+  // so it goes transparent with light ink to blend with the hero surface. Once
+  // scrolled it switches to the frosted, theme-aware look.
+  const navSurface = scrolled
+    ? 'bg-white/90 dark:bg-night/90 backdrop-blur-md border-b border-gray-200/40 dark:border-border'
+    : 'bg-transparent border-b border-transparent';
+  const linkColor = scrolled
+    ? 'text-gray-700 dark:text-gray-400'
+    : 'text-white/90';
+  const linkHover = scrolled
+    ? 'hover:text-primary-600 dark:hover:text-primary-300 hover:border-primary-500'
+    : 'hover:text-white hover:border-violet-a';
+
   return (
-    <nav className='sticky top-0 z-100 w-full bg-white/90 dark:bg-night/90 backdrop-blur-md border-b border-gray-200/40 dark:border-border px-6 py-3 transition-all duration-300'>
+    <nav
+      className={`sticky top-0 z-100 w-full px-6 py-3 transition-all duration-300 ${navSurface}`}
+    >
       <div className='flex flex-wrap items-center justify-between'>
         <Link
           href='/'
@@ -21,11 +44,15 @@ const Navigation = () => {
           Yunior B.
         </Link>
         <div className='flex items-center space-x-8'>
-          <ModeToggle />
+          <ModeToggle onHero={!scrolled} />
           <button
             onClick={() => setIsOpen(!isOpen)}
             type='button'
-            className='inline-flex items-center rounded-lg p-2 text-sm text-gray-500 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600 md:hidden'
+            className={`inline-flex items-center rounded-lg p-2 text-sm focus:outline-none focus:ring-2 md:hidden ${
+              scrolled
+                ? 'text-gray-500 hover:bg-gray-100 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600'
+                : 'text-white/80 hover:bg-white/10 focus:ring-white/40'
+            }`}
             aria-controls='navbar-collapse'
             aria-expanded={isOpen}
           >
@@ -71,9 +98,9 @@ const Navigation = () => {
                 href='#skills'
                 aria-label='How I build and the tools I use'
                 onClick={handleNavLinkClick}
-                className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
+                className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
+                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
                   How I Build
                 </span>
               </a>
@@ -83,9 +110,9 @@ const Navigation = () => {
                 href='#projects'
                 aria-label='Some projects I have built'
                 onClick={handleNavLinkClick}
-                className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
+                className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
+                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
                   Some Projects I&apos;ve Built
                 </span>
               </a>
@@ -95,9 +122,9 @@ const Navigation = () => {
                 href='#contact'
                 aria-label="Let's connect"
                 onClick={handleNavLinkClick}
-                className='block py-2 pr-4 pl-3 text-gray-700 dark:text-gray-400 md:p-0'
+                className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className='pb-1 hover:text-primary-600 dark:hover:text-primary-300 hover:border-b-2 hover:border-primary-500 hover:border-spacing-4'>
+                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
                   Let&apos;s Connect
                 </span>
               </a>


### PR DESCRIPTION
## What
Fix the hero light-mode diagonal gradient "flash" line and make the sticky nav scroll-aware in both themes.

### Hero gradient (light mode only)
- `background-size` scoped to `500% 500%` under `.light .animated-background`.
- The 300% crop exposed two adjacent translucent `rgba` stops that composite bright wash bands over the white page surface, painting a hard diagonal line; the 500% crop collapses it into a smooth sweep. Dark mode keeps the 300% framing.

### Scroll-aware sticky nav
- Nav is transparent with light ink at the top so it shares the (dark-in-both-themes) hero surface, then frosts to the theme surface once scrolled, and reverts when back at the top.
- Hero now fills the first viewport behind the nav (`-mt-16 min-h-[calc(100vh+4rem)]`), while a full-page wrapper keeps the sticky nav pinned for the whole scroll (fixes the nav scrolling away past the hero).
- `ModeToggle` accepts `onHero` to force the white moon icon while over the hero.

## Verification
- Fresh `npm run build` + `next start`; Playwright check in dark + light: nav pinned at scrollY 0/600/bottom, transparent-over-hero at top, frosted while scrolling, transparent again at top.
- `tsc --noEmit` clean; jest Home + Hero suites 7/7 pass.
