### PR TITLE
docs: update README to reflect portfolio's focus and tech stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,57 @@
-# Yunior Batista — Portfolio
+# Yunior Batista — Senior Frontend Engineer Portfolio
 
-A personal portfolio website built with **Next.js 16** and **React 19**, showcasing projects, skills, and a contact form. Features a modern glassmorphism design with animated backgrounds, dark mode, and smooth Framer Motion transitions.
+[View the live site](https://www.yuniorbatista.com/) · [View the accessible resume](https://www.yuniorbatista.com/resume) · [Download the resume PDF](https://www.yuniorbatista.com/Yunior-Batista-Resume.pdf)
 
-## Recent migration events
+This is the source for Yunior Batista's portfolio: a product-minded Senior Frontend Engineer with 8+ years of experience building scalable, accessible web applications and digital products. It is designed to demonstrate the same standards brought to production work—clear information architecture, maintainable component systems, measurable performance, accessibility, and dependable delivery.
 
-Modern toolchain — **SWC-only** (no Babel dep), **Tailwind v4** (CSS-first,
-no autoprefixer), **LF line endings enforced by `.gitattributes`**.
+## What this portfolio demonstrates
 
-- [#78](https://github.com/batistaDev1113/Portfolio/pull/78) Prettier CRLF auto-fix across 7 files
-- [#79](https://github.com/batistaDev1113/Portfolio/pull/79) Tailwind v3 → v4 (dropped autoprefixer)
-- [#80](https://github.com/batistaDev1113/Portfolio/pull/80) `.gitattributes` LF gate on `*.js/tsx/json/md`
-- [#83](https://github.com/batistaDev1113/Portfolio/pull/83) Drop Babel devDeps; next/jest SWC compiles tests
+- **Frontend architecture:** Reusable, typed React and Next.js components, thoughtful data boundaries, and a design-token system that keeps the interface consistent as it grows.
+- **Accessible product engineering:** Semantic structure, keyboard-aware interactions, focus management, reduced-motion support, and an HTML resume that is usable with screen readers.
+- **Performance-minded delivery:** Static routes, `next/image` optimization, lazy-loaded non-critical sections, and CSS-first motion that avoids adding hydration work to the critical path.
+- **Quality as part of the build:** TypeScript, Jest and React Testing Library coverage, Playwright hero regression testing, dependency auditing, and CI checks for every pull request.
 
-Full Path 4 rationale: [ADR 0009](docs/adr/0009-drop-babel-toolchain.md).
+## Selected work
 
-## Tech Stack
+### Portfolio platform
 
-| Category | Technology |
-|---|---|
-| Framework | Next.js 16 (App Router) |
-| Language | TypeScript |
-| Styling | Tailwind CSS 3 + custom CSS (glassmorphism) |
-| Font | Inter (Google Fonts via `next/font`) |
-| Animations | Framer Motion 12 |
-| Dark Mode | next-themes |
-| Icons | react-icons |
-| Email | Mailjet API |
-| Analytics | Vercel Analytics |
-| Error Monitoring | Sentry |
-| Testing | Jest + React Testing Library |
+A performance-focused portfolio built as a small production application rather than a static template. It uses a shared Tailwind v4 token system, responsive imagery, accessible dark mode, project case studies, and a server-side contact workflow.
 
-## Features
+The live mobile audit reports **93 Performance, 100 Accessibility, 100 Best Practices, and 100 SEO**. The project’s performance budget targets a 90+ mobile Lighthouse score and near-zero CLS before changes merge.
 
-**Sticky Navigation** — Full-width header with blur backdrop (`backdrop-blur-md`) that stays above all content (`z-[100]`). Includes a dark/light mode toggle and smooth anchor links.
+### Kanban Board
 
-**Animated Hero** — Full-screen section with an animated 4-color gradient background, glassmorphism card, floating profile image with rotating gradient ring, and staggered Framer Motion entrance animations. Links to view and download resume.
+A full-stack task-management experience where authenticated users create, reorder, and persist work across board columns. The project demonstrates practical product concerns beyond a UI mockup: drag-and-drop interactions, API-backed state, a database, and authentication.
 
-**Project Showcase** — Responsive 1→2→3 column grid of glassmorphism project cards with hover lift effects. Each card shows a screenshot, description, and up to 3 tech tags. A lazy-loaded modal reveals GitHub and live demo links with an Escape key handler and scroll-lock.
+See the portfolio’s [project case studies](https://www.yuniorbatista.com/#projects) for the problem, technical decisions, and outcomes behind each project.
 
-**Contact Form** — Split-layout section with a 3D CSS envelope illustration and a validated contact form (name, email, message). Submissions are sent via the Mailjet API through a Next.js API route.
+## Tech stack
 
-**Dark Mode** — Full light and dark theme support throughout all components.
+| Area | Technology |
+| --- | --- |
+| Framework | Next.js 16, React 19, TypeScript |
+| UI system | Tailwind CSS 4, CSS custom properties, responsive design, dark mode |
+| Frontend practice | Component architecture, accessibility, Core Web Vitals, responsive images |
+| Quality | Jest, React Testing Library, Playwright, ESLint, Prettier |
+| Delivery and observability | GitHub Actions, Vercel Analytics, Sentry, Vercel |
+| Contact workflow | Next.js route handler and Mailjet API |
 
-**Responsive** — Mobile-first layout, tested across phone, tablet, and desktop breakpoints.
+## Site capabilities
 
-## Getting Started
+- A focused senior-engineer introduction, availability status, social links, and accessible HTML/PDF resume options.
+- Skills organized around frontend architecture, accessibility, performance, and quality tooling—not only a list of frameworks.
+- Responsive project cards and individual case-study routes that explain problems, decisions, outcomes, and next steps.
+- A validated contact form that delivers messages through a server-side Mailjet integration.
+- Light and dark themes, responsive layouts, and motion that respects user preferences.
+
+## Local development
+
+### Prerequisites
+
+- Node.js 22.x
+- npm
+
+### Run the app
 
 ```bash
 git clone https://github.com/batistaDev1113/Portfolio.git
@@ -53,31 +60,48 @@ npm install
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) in your browser.
+Open [http://localhost:3000](http://localhost:3000).
 
-## Environment Variables
+### Environment variables
 
-Create a `.env.local` file in the project root with:
+Create `.env.local` in the project root to enable the contact form:
 
-```
+```bash
 MAILJET_API_KEY=your_mailjet_api_key
 MAILJET_SECRET_KEY=your_mailjet_secret_key
 ```
 
-## Scripts
+## Commands
 
 | Command | Description |
-|---|---|
-| `npm run dev` | Start development server |
-| `npm run build` | Build for production |
-| `npm run start` | Start production server |
-| `npm run lint` | Lint and auto-fix |
-| `npm run format` | Format with Prettier |
-| `npm run test` | Run Jest tests in watch mode |
+| --- | --- |
+| `npm run dev` | Start the development server. |
+| `npm run build` | Create a production build. |
+| `npm run start` | Serve the production build. |
+| `npm run lint:check` | Run ESLint without changing files. |
+| `npm run lint` | Run ESLint and apply supported fixes. |
+| `npm run format` | Format supported source files with Prettier. |
+| `npm test -- --watchAll=false` | Run Jest once. |
+| `npm run build && npm run test:e2e` | Build first, then run the Playwright suite. |
 
-## Contributing
+## Project structure
 
-Issues and pull requests are welcome. Please open an issue first to discuss any significant changes.
+```text
+app/          Next.js routes, API handlers, metadata, and global styles
+components/   Reusable UI sections and interaction components
+data/         Project content and case-study data
+public/       Images and downloadable resume assets
+__tests__/    Unit, component, route, and end-to-end coverage
+.github/      CI workflows for quality, security, and smoke checks
+```
+
+## Quality and delivery
+
+The repository treats quality gates as part of the product. Pull-request workflows include linting, type checking, unit tests, a Playwright hero regression check, production smoke coverage, and a critical-level production-dependency audit. The codebase also documents important operational decisions in [`docs/adr`](docs/adr).
+
+## Contact
+
+For roles, consulting, or product collaboration, use the [live-site contact form](https://www.yuniorbatista.com/#contact), [LinkedIn](https://www.linkedin.com/in/yunior-profile/), or [GitHub](https://github.com/batistaDev1113).
 
 ## License
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->
<!-- Fallback for human contributors opening PRs via the GitHub web UI.
     Agentic/automated runs should still use `gh pr create --body-file <path>`
     per the canonical pattern documented in AGENTS.md
     (`## gh CLI: do not use --yes on gh pr merge` section). -->

## Summary

<!-- 1-3 sentences describing what the change does and why. -->

## Type of change

<!-- Pick: bug fix / new feature / chore / refactor / docs / test -->

## Test plan

<!-- Which gates were run before opening this PR?
     (lint / tsc / jest / build / audit / manual smoke test) -->

## Reviewer checklist

<!-- Reminders for the reviewer -->

- If your PR adds or modifies `AGENTS.md`, review the new
  `## Tool quirks` section for any newly-discovered tool-shape
  failures; cross-link forward references inside the section body.
