### PR TITLE
feat(styles): centralize colors into design tokens + lib/colors.ts

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,3 +1,5 @@
+import { emailColors, emailGradients } from '../../../lib/colors';
+
 export const POST = async (req: Request) => {
   try {
     // Check if Mailjet API keys are configured
@@ -28,12 +30,12 @@ export const POST = async (req: Request) => {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>New Contact Message</title>
     </head>
-    <body style="margin: 0; padding: 0; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+    <body style="margin: 0; padding: 0; background: ${emailGradients.brand}; font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;"> 
       <div style="max-width: 650px; margin: 0 auto; padding: 40px 20px;">
         
         <!-- Header Section -->
         <div style="text-align: center; margin-bottom: 40px;">
-          <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: inline-block; padding: 20px 40px; border-radius: 50px; box-shadow: 0 10px 30px rgba(0,0,0,0.2);">
+          <div style="background: ${emailGradients.brand}; display: inline-block; padding: 20px 40px; border-radius: 50px; box-shadow: 0 10px 30px ${emailColors.shadowStrong};">
             <h1 style="color: white; margin: 0; font-size: 24px; font-weight: 600; letter-spacing: 1px;">
               📩 New Portfolio Message
             </h1>
@@ -41,68 +43,68 @@ export const POST = async (req: Request) => {
         </div>
 
         <!-- Main Content Card -->
-        <div style="background: white; border-radius: 20px; padding: 40px; box-shadow: 0 20px 60px rgba(0,0,0,0.1); position: relative; overflow: hidden;">
+        <div style="background: white; border-radius: 20px; padding: 40px; box-shadow: 0 20px 60px ${emailColors.shadowSoft}; position: relative; overflow: hidden;">
           
           <!-- Decorative gradient bar -->
-          <div style="position: absolute; top: 0; left: 0; right: 0; height: 6px; background: linear-gradient(90deg, #667eea 0%, #764ba2 50%, #f093fb 100%);"></div>
+          <div style="position: absolute; top: 0; left: 0; right: 0; height: 6px; background: ${emailGradients.brandAccent};"></div>
           
           <!-- Message Header -->
           <div style="text-align: center; margin-bottom: 35px;">
-            <h2 style="color: #2d3748; margin: 0; font-size: 28px; font-weight: 700; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">
+            <h2 style="color: ${emailColors.heading}; margin: 0; font-size: 28px; font-weight: 700; background: ${emailGradients.brand}; -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text;">
               You have a new message!
             </h2>
-            <p style="color: #718096; margin: 10px 0 0 0; font-size: 16px;">
+            <p style="color: ${emailColors.muted}; margin: 10px 0 0 0; font-size: 16px;">
               Someone reached out through your portfolio contact form
             </p>
           </div>
 
           <!-- Contact Information -->
           <div style="margin-bottom: 35px;">
-            <div style="display: flex; align-items: center; margin-bottom: 20px; padding: 20px; background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%); border-radius: 15px; border-left: 5px solid #667eea;">
-              <div style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; width: 50px; height: 50px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 20px; font-size: 20px; font-weight: bold;">
+            <div style="display: flex; align-items: center; margin-bottom: 20px; padding: 20px; background: ${emailGradients.field}; border-radius: 15px; border-left: 5px solid ${emailColors.gradientPrimary};">
+              <div style="background: ${emailGradients.brand}; color: white; width: 50px; height: 50px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 20px; font-size: 20px; font-weight: bold;">
                 👤
               </div>
               <div>
-                <p style="margin: 0 0 5px 0; color: #4a5568; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">From</p>
-                <p style="margin: 0; color: #2d3748; font-size: 18px; font-weight: 600;">${body.full_name}</p>
+                <p style="margin: 0 0 5px 0; color: ${emailColors.label}; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">From</p>
+                <p style="margin: 0; color: ${emailColors.heading}; font-size: 18px; font-weight: 600;">${body.full_name}</p>
               </div>
             </div>
 
-            <div style="display: flex; align-items: center; margin-bottom: 20px; padding: 20px; background: linear-gradient(135deg, #f7fafc 0%, #edf2f7 100%); border-radius: 15px; border-left: 5px solid #764ba2;">
-              <div style="background: linear-gradient(135deg, #764ba2 0%, #f093fb 100%); color: white; width: 50px; height: 50px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 20px; font-size: 20px; font-weight: bold;">
+            <div style="display: flex; align-items: center; margin-bottom: 20px; padding: 20px; background: ${emailGradients.field}; border-radius: 15px; border-left: 5px solid ${emailColors.gradientSecondary};">
+              <div style="background: ${emailGradients.avatarSecondary}; color: white; width: 50px; height: 50px; border-radius: 50%; display: flex; align-items: center; justify-content: center; margin-right: 20px; font-size: 20px; font-weight: bold;">
                 📧
               </div>
               <div>
-                <p style="margin: 0 0 5px 0; color: #4a5568; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">Email</p>
-                <p style="margin: 0; color: #2d3748; font-size: 18px; font-weight: 600;">${body.email}</p>
+                <p style="margin: 0 0 5px 0; color: ${emailColors.label}; font-size: 14px; font-weight: 600; text-transform: uppercase; letter-spacing: 1px;">Email</p>
+                <p style="margin: 0; color: ${emailColors.heading}; font-size: 18px; font-weight: 600;">${body.email}</p>
               </div>
             </div>
           </div>
 
           <!-- Message Content -->
           <div style="margin-bottom: 30px;">
-            <h3 style="color: #2d3748; margin: 0 0 20px 0; font-size: 20px; font-weight: 600; display: flex; align-items: center;">
-              <span style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; width: 40px; height: 40px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; margin-right: 15px; font-size: 16px;">💬</span>
+            <h3 style="color: ${emailColors.heading}; margin: 0 0 20px 0; font-size: 20px; font-weight: 600; display: flex; align-items: center;">
+              <span style="background: ${emailGradients.brand}; color: white; width: 40px; height: 40px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; margin-right: 15px; font-size: 16px;">💬</span>
               Message
             </h3>
-            <div style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); padding: 25px; border-radius: 15px; border: 2px solid #e2e8f0; position: relative;">
-              <div style="position: absolute; top: -2px; left: -2px; right: -2px; bottom: -2px; background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%); border-radius: 15px; z-index: -1; opacity: 0.1;"></div>
-              <p style="color: #2d3748; margin: 0; font-size: 16px; line-height: 1.6; white-space: pre-wrap;">${body.textarea}</p>
+            <div style="background: ${emailGradients.message}; padding: 25px; border-radius: 15px; border: 2px solid ${emailColors.messageBackgroundEnd}; position: relative;">
+              <div style="position: absolute; top: -2px; left: -2px; right: -2px; bottom: -2px; background: ${emailGradients.brandAccentCorner}; border-radius: 15px; z-index: -1; opacity: 0.1;"></div>
+              <p style="color: ${emailColors.heading}; margin: 0; font-size: 16px; line-height: 1.6; white-space: pre-wrap;">${body.textarea}</p>
             </div>
           </div>
 
           <!-- Call to Action -->
-          <div style="text-align: center; padding: 30px 0; border-top: 1px solid #e2e8f0;">
-            <a href="mailto:${body.email}" style="display: inline-block; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); color: white; text-decoration: none; padding: 15px 30px; border-radius: 50px; font-size: 16px; font-weight: 600; box-shadow: 0 10px 25px rgba(102, 126, 234, 0.3); transition: all 0.3s ease;">
+          <div style="text-align: center; padding: 30px 0; border-top: 1px solid ${emailColors.messageBackgroundEnd};">
+            <a href="mailto:${body.email}" style="display: inline-block; background: ${emailGradients.brand}; color: white; text-decoration: none; padding: 15px 30px; border-radius: 50px; font-size: 16px; font-weight: 600; box-shadow: 0 10px 25px ${emailColors.ctaGlow}; transition: all 0.3s ease;">
               📨 Reply to ${body.full_name}
             </a>
           </div>
 
           <!-- Footer -->
-          <div style="text-align: center; margin-top: 30px; padding-top: 25px; border-top: 1px solid #e2e8f0;">
-            <p style="color: #718096; margin: 0; font-size: 14px;">
+          <div style="text-align: center; margin-top: 30px; padding-top: 25px; border-top: 1px solid ${emailColors.messageBackgroundEnd};">
+            <p style="color: ${emailColors.muted}; margin: 0; font-size: 14px;">
               This message was sent through your portfolio contact form<br>
-              <span style="font-size: 12px; color: #a0aec0;">Received on ${new Date().toLocaleDateString(
+              <span style="font-size: 12px; color: ${emailColors.footer};">Received on ${new Date().toLocaleDateString(
                 'en-US',
                 {
                   weekday: 'long',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -90,7 +90,7 @@ const RootLayout: FC<RootLayoutProps> = ({ children }) => {
       >
         <a
           href='#main-content'
-          className='sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded focus:bg-white focus:text-black dark:focus:bg-gray-900 dark:focus:text-white'
+          className='sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:px-4 focus:py-2 focus:rounded focus:bg-white focus:text-black dark:focus:bg-ink-900 dark:focus:text-white'
         >
           Skip to main content
         </a>

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -3,23 +3,23 @@ import Link from 'next/link';
 
 const NotFound = () => {
   return (
-    <section className='bg-white dark:bg-gray-900 '>
+    <section className='bg-white dark:bg-ink-900 '>
       <div className='container min-h-screen px-6 py-12 mx-auto lg:flex lg:items-center lg:gap-12'>
         <div className='wf-ull lg:w-1/2'>
-          <p className='text-sm font-medium text-blue-500 dark:text-blue-400'>
+          <p className='text-sm font-medium text-info-500 dark:text-info-400'>
             404 error
           </p>
-          <h1 className='mt-3 text-2xl font-semibold text-gray-800 dark:text-white md:text-3xl'>
+          <h1 className='mt-3 text-2xl font-semibold text-ink-800 dark:text-white md:text-3xl'>
             Page not found
           </h1>
-          <p className='mt-4 text-gray-500 dark:text-gray-400'>
+          <p className='mt-4 text-ink-500 dark:text-ink-400'>
             Sorry, the page you are looking for doesn&#39;t exist.
           </p>
 
           <div className='flex items-center mt-6 gap-x-3'>
             <Link
               href='/'
-              className='w-1/2 px-5 py-2 text-sm tracking-wide text-white transition-colors duration-200 bg-blue-500 rounded-lg shrink-0 sm:w-auto hover:bg-blue-600 dark:hover:bg-blue-500 dark:bg-blue-600'
+              className='w-1/2 px-5 py-2 text-sm tracking-wide text-white transition-colors duration-200 bg-info-500 rounded-lg shrink-0 sm:w-auto hover:bg-info-600 dark:hover:bg-info-500 dark:bg-info-600'
             >
               Take me home
             </Link>

--- a/app/og-preview/route.tsx
+++ b/app/og-preview/route.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from 'next/og';
+import { ogColors } from '../../lib/colors';
 
 export const runtime = 'nodejs';
 export const alt = 'Yunior Batista — Senior Frontend Engineer';
@@ -7,58 +8,55 @@ export const contentType = 'image/png';
 
 export async function GET() {
   return new ImageResponse(
-    (
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        justifyContent: 'center',
+        padding: '64px 80px',
+        background: `linear-gradient(135deg, ${ogColors.backgroundStart} 0%, ${ogColors.backgroundMid} 45%, ${ogColors.backgroundEnd} 100%)`,
+        color: 'white',
+        fontFamily: 'sans-serif',
+      }}
+    >
       <div
         style={{
-          width: '100%',
-          height: '100%',
+          fontSize: 64,
+          fontWeight: 800,
+          letterSpacing: -1,
           display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-start',
-          justifyContent: 'center',
-          padding: '64px 80px',
-          background:
-            'linear-gradient(135deg, #07090f 0%, #111623 45%, #1e1b4b 100%)',
-          color: 'white',
-          fontFamily: 'sans-serif',
+          width: '100%',
         }}
       >
-        <div
-          style={{
-            fontSize: 64,
-            fontWeight: 800,
-            letterSpacing: -1,
-            display: 'flex',
-            width: '100%',
-          }}
-        >
-          Yunior Batista
-        </div>
-        <div
-          style={{
-            marginTop: 16,
-            fontSize: 28,
-            display: 'flex',
-            color: '#a5b4fc',
-            letterSpacing: 2,
-          }}
-        >
-          SENIOR FRONTEND ENGINEER
-        </div>
-        <div
-          style={{
-            marginTop: 48,
-            fontSize: 24,
-            display: 'flex',
-            color: '#cbd5e1',
-            maxWidth: 800,
-          }}
-        >
-          Building accessible, high-performance web experiences with React,
-          Next.js & TypeScript.
-        </div>
+        Yunior Batista
       </div>
-    ),
+      <div
+        style={{
+          marginTop: 16,
+          fontSize: 28,
+          display: 'flex',
+          color: ogColors.title,
+          letterSpacing: 2,
+        }}
+      >
+        SENIOR FRONTEND ENGINEER
+      </div>
+      <div
+        style={{
+          marginTop: 48,
+          fontSize: 24,
+          display: 'flex',
+          color: ogColors.body,
+          maxWidth: 800,
+        }}
+      >
+        Building accessible, high-performance web experiences with React,
+        Next.js & TypeScript.
+      </div>
+    </div>,
     size
   );
 }

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default async function ProjectPage({ params }: Props) {
           <FaArrowLeft className='h-3.5 w-3.5' />
           Back to work
         </Link>
-        <span className='font-mono text-xs uppercase tracking-[0.16em] text-gray-400 dark:text-gray-500'>
+        <span className='font-mono text-xs uppercase tracking-[0.16em] text-ink-400 dark:text-ink-500'>
           Case Study
         </span>
       </div>
@@ -67,10 +67,10 @@ export default async function ProjectPage({ params }: Props) {
         <div className='grid grid-cols-1 items-center gap-10 lg:grid-cols-2'>
           <div>
             <SectionLabel>// Project</SectionLabel>
-            <h1 className='fluid-title mt-4 text-gray-900 dark:text-white'>
+            <h1 className='fluid-title mt-4 text-ink-900 dark:text-white'>
               {name}
             </h1>
-            <p className='mt-4 text-base leading-7 text-gray-700 dark:text-gray-300'>
+            <p className='mt-4 text-base leading-7 text-ink-700 dark:text-ink-300'>
               {description}
             </p>
             <p className='mt-5 inline-flex items-center gap-2 rounded-lg bg-primary-50 px-4 py-2.5 text-sm font-semibold text-primary-700 dark:bg-primary-500/10 dark:text-primary-300'>
@@ -99,7 +99,7 @@ export default async function ProjectPage({ params }: Props) {
                   href={githubLink}
                   target='_blank'
                   rel='noopener noreferrer'
-                  className='inline-flex items-center gap-2 rounded-lg border border-gray-300 px-5 py-3 text-sm font-semibold text-gray-700 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-600 dark:border-gray-700 dark:text-gray-300 dark:hover:text-primary-300'
+                  className='inline-flex items-center gap-2 rounded-lg border border-ink-300 px-5 py-3 text-sm font-semibold text-ink-700 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-500 hover:text-primary-600 dark:border-ink-700 dark:text-ink-300 dark:hover:text-primary-300'
                 >
                   <FaGithub className='h-4 w-4' />
                   Source
@@ -125,14 +125,14 @@ export default async function ProjectPage({ params }: Props) {
         <div className='space-y-12'>
           <div>
             <SectionLabel>// Problem</SectionLabel>
-            <p className='mt-4 max-w-3xl text-lg leading-8 text-gray-700 dark:text-gray-300'>
+            <p className='mt-4 max-w-3xl text-lg leading-8 text-ink-700 dark:text-ink-300'>
               {problem}
             </p>
           </div>
 
           <div>
             <SectionLabel>// Approach</SectionLabel>
-            <p className='mt-4 max-w-3xl text-lg leading-8 text-gray-700 dark:text-gray-300'>
+            <p className='mt-4 max-w-3xl text-lg leading-8 text-ink-700 dark:text-ink-300'>
               {approach}
             </p>
           </div>
@@ -146,7 +146,7 @@ export default async function ProjectPage({ params }: Props) {
                     className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-primary-500'
                     aria-hidden='true'
                   />
-                  <span className='max-w-3xl text-base leading-7 text-gray-700 dark:text-gray-300'>
+                  <span className='max-w-3xl text-base leading-7 text-ink-700 dark:text-ink-300'>
                     {decision}
                   </span>
                 </li>
@@ -156,7 +156,7 @@ export default async function ProjectPage({ params }: Props) {
 
           <div>
             <SectionLabel>// Outcome</SectionLabel>
-            <p className='mt-4 max-w-3xl text-lg leading-8 text-gray-700 dark:text-gray-300'>
+            <p className='mt-4 max-w-3xl text-lg leading-8 text-ink-700 dark:text-ink-300'>
               {outcome}
             </p>
           </div>
@@ -171,7 +171,7 @@ export default async function ProjectPage({ params }: Props) {
                       className='mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-violet-a'
                       aria-hidden='true'
                     />
-                    <span className='max-w-3xl text-base leading-7 text-gray-700 dark:text-gray-300'>
+                    <span className='max-w-3xl text-base leading-7 text-ink-700 dark:text-ink-300'>
                       {improvement}
                     </span>
                   </li>

--- a/app/resume/page.tsx
+++ b/app/resume/page.tsx
@@ -3,39 +3,39 @@ export default function ResumePage() {
     <main className='min-h-screen px-6 py-12 md:px-10 lg:px-16'>
       <article className='mx-auto max-w-4xl space-y-10'>
         <header className='space-y-4'>
-          <p className='text-sm uppercase tracking-wide text-gray-500'>
+          <p className='text-sm uppercase tracking-wide text-ink-500'>
             Accessible Resume
           </p>
-          <h1 className='text-4xl font-bold tracking-tight text-gray-900 dark:text-gray-100'>
+          <h1 className='text-4xl font-bold tracking-tight text-ink-900 dark:text-ink-100'>
             Yunior Batista
           </h1>
-          <p className='text-lg text-gray-700 dark:text-gray-300'>
+          <p className='text-lg text-ink-700 dark:text-ink-300'>
             Senior Frontend Engineer
           </p>
-          <p className='text-sm text-gray-700 dark:text-gray-300'>
+          <p className='text-sm text-ink-700 dark:text-ink-300'>
             Kissimmee, FL | 407-785-5587 | yuniorbatista1113@gmail.com
           </p>
-          <p className='text-sm text-gray-700 dark:text-gray-300'>
+          <p className='text-sm text-ink-700 dark:text-ink-300'>
             linkedin.com/in/yuniorbatista | yuniorbatista.com
           </p>
-          <p className='text-base text-gray-700 dark:text-gray-300'>
+          <p className='text-base text-ink-700 dark:text-ink-300'>
             Product-minded Software Engineer with 8+ years of experience
             building scalable, accessible, user-centered web applications and
             digital products. Expertise in frontend architecture, React,
             Next.js, TypeScript, Angular, Vue, and component-based application
             development.
           </p>
-          <p className='text-sm text-gray-600 dark:text-gray-400'>
+          <p className='text-sm text-ink-600 dark:text-ink-400'>
             Prefer a printable document? Return to the home page and use
             Download Resume to get the PDF.
           </p>
         </header>
 
         <section className='space-y-3'>
-          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h2 className='text-2xl font-semibold text-ink-900 dark:text-ink-100'>
             Summary
           </h2>
-          <p className='text-base leading-7 text-gray-700 dark:text-gray-300'>
+          <p className='text-base leading-7 text-ink-700 dark:text-ink-300'>
             Combines strong UX/UI judgment with technical leadership across
             system design, reusable component systems, API integration, testing
             strategy, performance, and reliable production delivery.
@@ -43,10 +43,10 @@ export default function ResumePage() {
         </section>
 
         <section className='space-y-3'>
-          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h2 className='text-2xl font-semibold text-ink-900 dark:text-ink-100'>
             Technical Skills
           </h2>
-          <div className='space-y-4 text-base text-gray-700 dark:text-gray-300'>
+          <div className='space-y-4 text-base text-ink-700 dark:text-ink-300'>
             <p>
               <span className='font-semibold'>Frontend:</span> React, Next.js,
               Angular, Vue.js, Vuetify, TypeScript, JavaScript, HTML5, CSS/SCSS,
@@ -76,18 +76,18 @@ export default function ResumePage() {
         </section>
 
         <section className='space-y-4'>
-          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h2 className='text-2xl font-semibold text-ink-900 dark:text-ink-100'>
             Professional Experience
           </h2>
 
           <section className='space-y-2'>
-            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
               Design Interactive - Software Engineer
             </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>
+            <p className='text-sm text-ink-600 dark:text-ink-400'>
               Remote | February 2024 - Present
             </p>
-            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
               <li>
                 Build and maintain secure, scalable enterprise web applications
                 supporting mission-critical government workflows and strict
@@ -125,13 +125,13 @@ export default function ResumePage() {
           </section>
 
           <section className='space-y-2'>
-            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
               Airship - Software Engineer
             </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>
+            <p className='text-sm text-ink-600 dark:text-ink-400'>
               Remote | January 2022 - November 2022
             </p>
-            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
               <li>
                 Developed and maintained 5+ responsive web applications using
                 React, Next.js, TypeScript, JavaScript, HTML, CSS, and Tailwind
@@ -156,13 +156,13 @@ export default function ResumePage() {
           </section>
 
           <section className='space-y-2'>
-            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
               Power Home Remodeling - UI Engineer
             </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>
+            <p className='text-sm text-ink-600 dark:text-ink-400'>
               Remote | May 2020 - January 2022
             </p>
-            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
               <li>
                 Developed and maintained reusable React components for an
                 internal design system using JavaScript, TypeScript, Redux, and
@@ -188,13 +188,13 @@ export default function ResumePage() {
           </section>
 
           <section className='space-y-2'>
-            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
               Darden Restaurants - Frontend Developer
             </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>
+            <p className='text-sm text-ink-600 dark:text-ink-400'>
               Orlando, FL | June 2019 - April 2020
             </p>
-            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
               <li>
                 Developed and executed A/B tests using JavaScript, jQuery, and
                 Adobe Target, contributing to a 20% increase in revenue through
@@ -214,13 +214,13 @@ export default function ResumePage() {
           </section>
 
           <section className='space-y-2'>
-            <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+            <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
               Visit Orlando - Frontend Developer
             </h3>
-            <p className='text-sm text-gray-600 dark:text-gray-400'>
+            <p className='text-sm text-ink-600 dark:text-ink-400'>
               Orlando, FL | January 2018 - April 2020
             </p>
-            <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+            <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
               <li>
                 Refactored and optimized web-development workflows using HTML,
                 JavaScript, and Agility CMS, improving development efficiency
@@ -241,16 +241,16 @@ export default function ResumePage() {
         </section>
 
         <section className='space-y-3'>
-          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h2 className='text-2xl font-semibold text-ink-900 dark:text-ink-100'>
             Project
           </h2>
-          <h3 className='text-xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h3 className='text-xl font-semibold text-ink-900 dark:text-ink-100'>
             Portfolio Website
           </h3>
-          <p className='text-sm text-gray-600 dark:text-gray-400'>
+          <p className='text-sm text-ink-600 dark:text-ink-400'>
             Next.js, React, TypeScript, Tailwind CSS, Framer Motion, SendGrid
           </p>
-          <ul className='list-disc space-y-2 pl-6 text-base text-gray-700 dark:text-gray-300'>
+          <ul className='list-disc space-y-2 pl-6 text-base text-ink-700 dark:text-ink-300'>
             <li>
               Designed and developed a responsive portfolio platform to showcase
               frontend engineering, UI/UX, and product-development work.
@@ -268,13 +268,13 @@ export default function ResumePage() {
         </section>
 
         <section className='space-y-3'>
-          <h2 className='text-2xl font-semibold text-gray-900 dark:text-gray-100'>
+          <h2 className='text-2xl font-semibold text-ink-900 dark:text-ink-100'>
             Education
           </h2>
-          <p className='text-base text-gray-700 dark:text-gray-300'>
+          <p className='text-base text-ink-700 dark:text-ink-300'>
             Bachelor of Science in Computer Science
           </p>
-          <p className='text-sm text-gray-600 dark:text-gray-400'>
+          <p className='text-sm text-ink-600 dark:text-ink-400'>
             Florida State University | Tallahassee, FL
           </p>
         </section>

--- a/app/styles/globals.css
+++ b/app/styles/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "./variables.css";
 @custom-variant dark (&:where(.dark, .dark *));
 @plugin "@tailwindcss/forms";
 
@@ -9,61 +10,12 @@
 @source "../../components/**/*.{js,jsx,ts,tsx}";
 @source "../../app/**/*.{js,jsx,ts,tsx}";
 
-/* Design tokens. Single indigo -> violet anchor (primary), layered dark
-   surfaces, and font families wired to the next/font variables loaded in
-   app/layout.tsx. Tailwind v4 emits utilities from the theme variables
-   (e.g. --color-primary -> bg-primary/text-primary, --font-display ->
-   font-display). */
-@theme {
-  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
-  --font-display: var(--font-space-grotesk), var(--font-inter), sans-serif;
-  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
-
-  --color-primary-50: #eef2ff;
-  --color-primary-100: #e0e7ff;
-  --color-primary-200: #c7d2fe;
-  --color-primary-300: #a5b4fc;
-  --color-primary-400: #818cf8;
-  --color-primary-500: #6366f1;
-  --color-primary-600: #4f46e5;
-  --color-primary-700: #4338ca;
-  --color-primary-800: #3730a3;
-  --color-primary-900: #312e81;
-
-  --color-violet-a: #8b5cf6;
-  --color-violet-b: #a78bfa;
-
-  /* Layered surfaces for dark mode: base -> raised -> elevated. */
-  --color-night: #07090f;
-  --color-surface: #0b0e16;
-  --color-raised: #111623;
-  --color-border: #1d2434;
-  --color-border-strong: #2a3347;
-
-  /* Light mode surfaces: near-white base + soft borders. */
-  --color-light-surface: #ffffff;
-}
-
 * {
   box-sizing: border-box;
 }
 
-:root {
-  --foreground-rgb: 255, 255, 255;
-  --background-start-rgb: #0e182a;
-  --background-end-rgb: #0e182a;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: #0e182a;
-    --background-end-rgb: #0e182a;
-  }
-}
-
 body {
-    @apply bg-light-surface dark:bg-night text-slate-900 dark:text-slate-100 transition-colors duration-300;
+    @apply bg-light-surface dark:bg-night text-body-text dark:text-body-text-dark transition-colors duration-300;
 }
 
 html {
@@ -139,14 +91,13 @@ html {
   .card-elevated {
     background: var(--color-light-surface);
     border: 1px solid var(--color-primary-100);
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
-      0 8px 24px rgba(15, 23, 42, 0.06);
+    box-shadow: var(--shadow-card);
   }
 
   .dark .card-elevated {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+    box-shadow: var(--shadow-card-dark);
   }
 
   /* Subtle top accent bar for branded cards. */
@@ -168,13 +119,13 @@ html {
     @apply my-4 inline-flex items-center justify-center px-8 py-3 text-base text-center text-white border-none rounded-lg transition-all duration-300 ease-out;
     background: linear-gradient(135deg, var(--color-primary-600) 0%, var(--color-violet-a) 100%);
     backdrop-filter: blur(10px);
-    box-shadow: 0 10px 25px rgba(79, 70, 229, 0.3);
+    box-shadow: var(--shadow-btn-primary);
     transform: translateY(0);
   }
 
   .button-about:hover {
     transform: translateY(-2px) scale(1.02);
-    box-shadow: 0 15px 35px rgba(79, 70, 229, 0.4);
+    box-shadow: var(--shadow-btn-primary-hover);
     background: linear-gradient(135deg, var(--color-primary-500) 0%, var(--color-violet-b) 100%);
   }
 
@@ -182,16 +133,16 @@ html {
      alongside .button-about as the "less important" action. */
   .button-quiet {
     @apply inline-flex items-center justify-center px-5 py-3 text-base text-center rounded-lg transition-all duration-300 ease-out;
-    color: rgba(255, 255, 255, 0.85);
-    border: 1px solid rgba(255, 255, 255, 0.22);
-    background: rgba(255, 255, 255, 0.04);
+    color: var(--color-glass-text);
+    border: 1px solid var(--color-glass-border);
+    background: var(--color-glass-fill-faint);
     backdrop-filter: blur(8px);
   }
 
   .button-quiet:hover {
     color: #fff;
-    border-color: rgba(255, 255, 255, 0.45);
-    background: rgba(255, 255, 255, 0.1);
+    border-color: var(--color-glass-border-hover);
+    background: var(--color-glass-fill-hover);
     transform: translateY(-2px);
   }
 
@@ -283,17 +234,17 @@ html {
 
   /* Glassmorphism Hero Card */
   .hero-card {
-    background: rgba(255, 255, 255, 0.08);
+    background: var(--color-glass-fill);
     backdrop-filter: blur(24px);
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.5);
+    border: 1px solid var(--color-glass-border-soft);
+    box-shadow: var(--shadow-hero-card);
     border-radius: 20px;
   }
 
   .dark .hero-card {
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    box-shadow: 0 25px 60px rgba(0, 0, 0, 0.6);
+    background: var(--color-glass-fill-dark);
+    border: 1px solid var(--color-glass-border-dark);
+    box-shadow: var(--shadow-hero-card-dark);
   }
 
   /* Animated Gradient Background.
@@ -307,12 +258,12 @@ html {
   .animated-background {
     background: linear-gradient(
       -45deg,
-      #020617,
-      #0f0c29,
-      rgba(79, 70, 229, 0.18),
-      #0a0f1e,
-      rgba(139, 92, 246, 0.16),
-      #140d2e
+      var(--color-hero-bg-start),
+      var(--color-hero-bg-mid),
+      var(--color-hero-glow-primary),
+      var(--color-hero-bg-deep),
+      var(--color-hero-glow-violet),
+      var(--color-hero-bg-end)
     );
     background-size: 300% 300%;
     background-position: 50% 50%;
@@ -425,25 +376,24 @@ html {
     overflow: hidden;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     position: relative;
-    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04),
-      0 8px 24px rgba(15, 23, 42, 0.06);
+    box-shadow: var(--shadow-card);
   }
 
   .dark .project-card {
     background: var(--color-surface);
     border: 1px solid var(--color-border);
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+    box-shadow: var(--shadow-card-dark);
   }
 
   .project-card:hover {
     transform: translateY(-6px);
-    box-shadow: 0 20px 45px rgba(79, 70, 229, 0.12);
+    box-shadow: var(--shadow-card-hover);
     border-color: var(--color-primary-300);
   }
 
   .dark .project-card:hover {
     border-color: var(--color-border-strong);
-    box-shadow: 0 25px 55px rgba(0, 0, 0, 0.5);
+    box-shadow: var(--shadow-card-hover-dark);
   }
 
   .project-image-overlay {
@@ -468,8 +418,8 @@ html {
     bottom: 0;
     background: linear-gradient(
       135deg,
-      rgba(79, 70, 229, 0.12) 0%,
-      rgba(139, 92, 246, 0.12) 100%
+      var(--color-brand-tint-overlay) 0%,
+      var(--color-violet-tint-overlay) 100%
     );
     opacity: 0;
     transition: opacity 0.3s ease;
@@ -529,17 +479,17 @@ html {
     font-family: var(--font-mono);
     font-size: 0.7rem;
     letter-spacing: 0.06em;
-    background: rgba(79, 70, 229, 0.06);
+    background: var(--color-brand-tint-soft);
     backdrop-filter: blur(10px);
-    border: 1px solid rgba(79, 70, 229, 0.16);
+    border: 1px solid var(--color-brand-tint-border);
     border-radius: 6px;
     padding: 0.3rem 0.6rem;
     color: var(--color-primary-700);
   }
 
   .dark .tech-tag {
-    background: rgba(129, 140, 248, 0.08);
-    border: 1px solid rgba(167, 139, 250, 0.22);
+    background: var(--color-brand-tint-dark);
+    border: 1px solid var(--color-violet-border-dark);
     color: var(--color-primary-300);
   }
 
@@ -550,9 +500,9 @@ html {
     letter-spacing: 0.06em;
     padding: 0.3rem 0.6rem;
     border-radius: 6px;
-    color: rgba(255, 255, 255, 0.9);
-    background: rgba(255, 255, 255, 0.12);
-    border: 1px solid rgba(255, 255, 255, 0.22);
+    color: var(--color-glass-text-strong);
+    background: var(--color-glass-fill-tag);
+    border: 1px solid var(--color-glass-border);
     backdrop-filter: blur(6px);
   }
 
@@ -676,8 +626,8 @@ html {
   font-size: 0.85rem;
   letter-spacing: 0.02em;
   color: var(--color-primary-700);
-  background: rgba(79, 70, 229, 0.05);
-  border: 1px solid rgba(79, 70, 229, 0.14);
+  background: var(--color-brand-tint-faint);
+  border: 1px solid var(--color-brand-tint-border-faint);
   border-radius: 9999px;
   padding: 0.45rem 1rem;
   transition: border-color 0.2s ease, background 0.2s ease;
@@ -691,5 +641,5 @@ html {
 
 .toolbox-item:hover {
   border-color: var(--color-primary-400);
-  background: rgba(79, 70, 229, 0.1);
+  background: var(--color-brand-tint-hover);
 }

--- a/app/styles/variables.css
+++ b/app/styles/variables.css
@@ -1,0 +1,140 @@
+/* Design tokens — single source of truth for every color on the site.
+   Imported by app/styles/globals.css (after the tailwindcss import) so
+   Tailwind v4 emits utilities from these theme variables. Kept in a
+   separate file so the token surface is reviewable independently of the
+   component styles that consume it.
+
+   Conventions:
+   - primary*: the single indigo -> violet anchor.
+   - ink*:      Tailwind gray scale (unchanged values) for neutral text/borders.
+   - info*:     blue family (links, focus rings).
+   - danger*:   red family (form errors).
+   - success*:  green family (form success states).
+   - live:      emerald accent (hero availability dot).
+   - hero-*:    hero-only colors (dark gradient text + animated backdrop).
+   - glass-*:   white-alpha fills/borders for frosted surfaces.
+   - brand-*:   primary/violet-alpha tints for chips and image overlays.
+   - shadow-*:  elevation presets (usable as `shadow-card`, etc.). */
+
+@theme {
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --font-display: var(--font-space-grotesk), var(--font-inter), sans-serif;
+  --font-mono: var(--font-jetbrains-mono), ui-monospace, monospace;
+
+  --color-primary-50: #eef2ff;
+  --color-primary-100: #e0e7ff;
+  --color-primary-200: #c7d2fe;
+  --color-primary-300: #a5b4fc;
+  --color-primary-400: #818cf8;
+  --color-primary-500: #6366f1;
+  --color-primary-600: #4f46e5;
+  --color-primary-700: #4338ca;
+  --color-primary-800: #3730a3;
+  --color-primary-900: #312e81;
+
+  --color-violet-a: #8b5cf6;
+  --color-violet-b: #a78bfa;
+
+  /* Layered surfaces for dark mode: base -> raised -> elevated. */
+  --color-night: #07090f;
+  --color-surface: #0b0e16;
+  --color-raised: #111623;
+  --color-border: #1d2434;
+  --color-border-strong: #2a3347;
+
+  /* Light mode surfaces: near-white base + soft borders. */
+  --color-light-surface: #ffffff;
+
+  /* Neutral ink scale (identical values to Tailwind gray). */
+  --color-ink-50: #f9fafb;
+  --color-ink-100: #f3f4f6;
+  --color-ink-200: #e5e7eb;
+  --color-ink-300: #d1d5db;
+  --color-ink-400: #9ca3af;
+  --color-ink-500: #6b7280;
+  --color-ink-600: #4b5563;
+  --color-ink-700: #374151;
+  --color-ink-800: #1f2937;
+  --color-ink-900: #111827;
+
+  /* Body text (former slate-900 / slate-100; kept distinct from ink because
+     the values differ). */
+  --color-body-text: #0f172a;
+  --color-body-text-dark: #f1f5f9;
+
+  /* Info (blue family). */
+  --color-info-200: #bfdbfe;
+  --color-info-400: #60a5fa;
+  --color-info-500: #3b82f6;
+  --color-info-600: #2563eb;
+
+  /* Danger (red family). */
+  --color-danger-50: #fef2f2;
+  --color-danger-200: #fecaca;
+  --color-danger-400: #f87171;
+  --color-danger-500: #ef4444;
+  --color-danger-600: #dc2626;
+  --color-danger-700: #b91c1c;
+  --color-danger-800: #991b1b;
+  --color-danger-900: #7f1d1d;
+
+  /* Success (green family). */
+  --color-success-50: #f0fdf4;
+  --color-success-200: #bbf7d0;
+  --color-success-400: #4ade80;
+  --color-success-500: #22c55e;
+  --color-success-700: #15803d;
+  --color-success-800: #166534;
+  --color-success-900: #14532d;
+
+  /* Live accent (emerald-400). */
+  --color-live: #34d399;
+
+  /* Hero gradient text (blue-200 -> violet-200 -> indigo-200). */
+  --color-hero-gradient-start: #bfdbfe;
+  --color-hero-gradient-mid: #ddd6fe;
+  --color-hero-gradient-end: #c7d2fe;
+
+  /* Animated hero backdrop stops + glow washes. */
+  --color-hero-bg-start: #020617;
+  --color-hero-bg-mid: #0f0c29;
+  --color-hero-bg-deep: #0a0f1e;
+  --color-hero-bg-end: #140d2e;
+  --color-hero-glow-primary: rgba(79, 70, 229, 0.18);
+  --color-hero-glow-violet: rgba(139, 92, 246, 0.16);
+
+  /* White-alpha glass surfaces. */
+  --color-glass-text: rgba(255, 255, 255, 0.85);
+  --color-glass-text-strong: rgba(255, 255, 255, 0.9);
+  --color-glass-fill: rgba(255, 255, 255, 0.08);
+  --color-glass-fill-dark: rgba(255, 255, 255, 0.05);
+  --color-glass-fill-tag: rgba(255, 255, 255, 0.12);
+  --color-glass-fill-faint: rgba(255, 255, 255, 0.04);
+  --color-glass-fill-hover: rgba(255, 255, 255, 0.1);
+  --color-glass-border: rgba(255, 255, 255, 0.22);
+  --color-glass-border-soft: rgba(255, 255, 255, 0.15);
+  --color-glass-border-dark: rgba(255, 255, 255, 0.12);
+  --color-glass-border-hover: rgba(255, 255, 255, 0.45);
+
+  /* Brand (primary/violet) alpha tints. */
+  --color-brand-tint-soft: rgba(79, 70, 229, 0.06);
+  --color-brand-tint-border: rgba(79, 70, 229, 0.16);
+  --color-brand-tint-hover: rgba(79, 70, 229, 0.1);
+  --color-brand-tint-faint: rgba(79, 70, 229, 0.05);
+  --color-brand-tint-border-faint: rgba(79, 70, 229, 0.14);
+  --color-brand-tint-overlay: rgba(79, 70, 229, 0.12);
+  --color-violet-tint-overlay: rgba(139, 92, 246, 0.12);
+  --color-brand-tint-dark: rgba(129, 140, 248, 0.08);
+  --color-violet-border-dark: rgba(167, 139, 250, 0.22);
+
+  /* Elevation presets. */
+  --shadow-card:
+    0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px rgba(15, 23, 42, 0.06);
+  --shadow-card-dark: 0 8px 30px rgba(0, 0, 0, 0.35);
+  --shadow-card-hover: 0 20px 45px rgba(79, 70, 229, 0.12);
+  --shadow-card-hover-dark: 0 25px 55px rgba(0, 0, 0, 0.5);
+  --shadow-btn-primary: 0 10px 25px rgba(79, 70, 229, 0.3);
+  --shadow-btn-primary-hover: 0 15px 35px rgba(79, 70, 229, 0.4);
+  --shadow-hero-card: 0 25px 60px rgba(0, 0, 0, 0.5);
+  --shadow-hero-card-dark: 0 25px 60px rgba(0, 0, 0, 0.6);
+}

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -22,7 +22,7 @@ const BackToTop = () => {
       type='button'
       onClick={scrollToTop}
       aria-label='Back to top'
-      className='inline-flex items-center gap-2 text-sm text-gray-500 hover:text-primary-600 hover:cursor-pointer dark:text-gray-400 dark:hover:text-primary-300 transition-colors font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 rounded px-2 py-1'
+      className='inline-flex items-center gap-2 text-sm text-ink-500 hover:text-primary-600 hover:cursor-pointer dark:text-ink-400 dark:hover:text-primary-300 transition-colors font-mono focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500/60 rounded px-2 py-1'
     >
       <FaArrowUp className='h-3.5 w-3.5' aria-hidden='true' />
       Back to top

--- a/components/ContactForm.tsx
+++ b/components/ContactForm.tsx
@@ -123,12 +123,12 @@ const ContactForm = memo(() => {
     >
       <div className='flex flex-col items-center mb-16'>
         <p className='eyebrow'>// 03 · Contact</p>
-        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+        <h2 className='fluid-title text-ink-900 dark:text-white mt-4 text-center'>
           Let&apos;s Connect
         </h2>
-        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
-          Have a project in mind, a role to discuss, or just want to say hi?
-          The form goes straight to my inbox.
+        <p className='mt-4 max-w-2xl text-center text-ink-600 dark:text-ink-400 text-sm sm:text-base leading-6'>
+          Have a project in mind, a role to discuss, or just want to say hi? The
+          form goes straight to my inbox.
         </p>
       </div>
 
@@ -136,7 +136,7 @@ const ContactForm = memo(() => {
         {/* Desktop Split Layout */}
         <div className='lg:grid lg:grid-cols-2 lg:min-h-150'>
           {/* Contact Info Panel */}
-          <section className='relative p-8 lg:p-12 bg-linear-to-br from-primary-800 via-primary-700 to-violet-a dark:from-[#0b0e16] dark:via-[#111623] dark:to-[#0b0e16] overflow-hidden flex flex-col justify-center gap-6 natural'>
+          <section className='relative p-8 lg:p-12 bg-linear-to-br from-primary-800 via-primary-700 to-violet-a dark:from-surface dark:via-raised dark:to-surface overflow-hidden flex flex-col justify-center gap-6 natural'>
             {/* Ambient glow */}
             <div className='absolute -top-24 -right-24 w-72 h-72 rounded-full bg-violet-a/25 blur-3xl pointer-events-none' />
             <div className='absolute -bottom-20 -left-16 w-64 h-64 rounded-full bg-primary-500/20 blur-3xl pointer-events-none' />
@@ -151,8 +151,8 @@ const ContactForm = memo(() => {
                 worth talking about.
               </h3>
               <p className='mt-4 text-sm text-white/70 leading-6 max-w-sm'>
-                I&apos;m always open to discussing new projects, creative
-                ideas, or opportunities to be part of your vision.
+                I&apos;m always open to discussing new projects, creative ideas,
+                or opportunities to be part of your vision.
               </p>
 
               <div className='mt-8 flex flex-wrap gap-3'>
@@ -187,13 +187,13 @@ const ContactForm = memo(() => {
           >
             {sending ? (
               <div className='flex flex-col items-center justify-center w-full text-center pop-in'>
-                <div className='w-20 h-20 bg-linear-to-r from-green-400 to-blue-500 rounded-full flex items-center justify-center mb-6'>
+                <div className='w-20 h-20 bg-linear-to-r from-success-400 to-info-500 rounded-full flex items-center justify-center mb-6'>
                   <FaRegPaperPlane className='text-2xl text-white animate-bounce' />
                 </div>
-                <h2 className='text-2xl font-semibold text-gray-900 dark:text-white mb-2'>
+                <h2 className='text-2xl font-semibold text-ink-900 dark:text-white mb-2'>
                   Message Sent!
                 </h2>
-                <p className='text-gray-600 dark:text-gray-400'>
+                <p className='text-ink-600 dark:text-ink-400'>
                   Thank you for reaching out. I&apos;ll get back to you soon.
                 </p>
               </div>
@@ -209,7 +209,7 @@ const ContactForm = memo(() => {
                   <div className='group'>
                     <label
                       htmlFor='FullName'
-                      className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'
+                      className='block text-sm font-medium text-ink-700 dark:text-ink-300 mb-2'
                     >
                       Full Name
                     </label>
@@ -227,16 +227,16 @@ const ContactForm = memo(() => {
                       }
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.fullName
-? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
-                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border`}
+                          ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500/20'
+                          : 'border-ink-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                      } bg-white dark:bg-surface text-ink-900 dark:text-ink-100 placeholder-ink-500 dark:placeholder-ink-400 focus:ring-2 transition-all duration-200 outline-none hover:border-ink-300 dark:hover:border-border`}
                       placeholder='Enter your full name'
                     />
                     {errors.fullName && (
                       <p
                         id={fullNameErrorId}
                         role='alert'
-                        className='mt-1 text-sm text-red-600 dark:text-red-400'
+                        className='mt-1 text-sm text-danger-600 dark:text-danger-400'
                       >
                         {errors.fullName}
                       </p>
@@ -247,7 +247,7 @@ const ContactForm = memo(() => {
                   <div className='group'>
                     <label
                       htmlFor='Email'
-                      className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'
+                      className='block text-sm font-medium text-ink-700 dark:text-ink-300 mb-2'
                     >
                       Email Address
                     </label>
@@ -263,16 +263,16 @@ const ContactForm = memo(() => {
                       aria-describedby={errors.email ? emailErrorId : undefined}
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.email
-? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
-                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border`}
+                          ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500/20'
+                          : 'border-ink-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                      } bg-white dark:bg-surface text-ink-900 dark:text-ink-100 placeholder-ink-500 dark:placeholder-ink-400 focus:ring-2 transition-all duration-200 outline-none hover:border-ink-300 dark:hover:border-border`}
                       placeholder='your.email@example.com'
                     />
                     {errors.email && (
                       <p
                         id={emailErrorId}
                         role='alert'
-                        className='mt-1 text-sm text-red-600 dark:text-red-400'
+                        className='mt-1 text-sm text-danger-600 dark:text-danger-400'
                       >
                         {errors.email}
                       </p>
@@ -283,7 +283,7 @@ const ContactForm = memo(() => {
                   <div className='group'>
                     <label
                       htmlFor='Message'
-                      className='block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2'
+                      className='block text-sm font-medium text-ink-700 dark:text-ink-300 mb-2'
                     >
                       Message
                     </label>
@@ -302,15 +302,15 @@ const ContactForm = memo(() => {
                       placeholder='Tell me about your project or just say hello...'
                       className={`w-full px-4 py-3 rounded-xl border ${
                         errors.message
-? 'border-red-500 focus:border-red-500 focus:ring-red-500/20'
-                      : 'border-gray-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
-                  } bg-white dark:bg-surface text-gray-900 dark:text-gray-100 placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 transition-all duration-200 outline-none hover:border-gray-300 dark:hover:border-border resize-none`}
+                          ? 'border-danger-500 focus:border-danger-500 focus:ring-danger-500/20'
+                          : 'border-ink-200 dark:border-border focus:border-primary-400 focus:ring-primary-400/20'
+                      } bg-white dark:bg-surface text-ink-900 dark:text-ink-100 placeholder-ink-500 dark:placeholder-ink-400 focus:ring-2 transition-all duration-200 outline-none hover:border-ink-300 dark:hover:border-border resize-none`}
                     />
                     {errors.message && (
                       <p
                         id={messageErrorId}
                         role='alert'
-                        className='mt-1 text-sm text-red-600 dark:text-red-400'
+                        className='mt-1 text-sm text-danger-600 dark:text-danger-400'
                       >
                         {errors.message}
                       </p>
@@ -345,8 +345,8 @@ const ContactForm = memo(() => {
                       }
                       className={`p-4 rounded-xl text-sm font-medium slide-in ${
                         message.includes('Error')
-                          ? 'bg-red-50 text-red-700 border border-red-200 dark:bg-red-900/20 dark:text-red-400 dark:border-red-800'
-                          : 'bg-green-50 text-green-700 border border-green-200 dark:bg-green-900/20 dark:text-green-400 dark:border-green-800'
+                          ? 'bg-danger-50 text-danger-700 border border-danger-200 dark:bg-danger-900/20 dark:text-danger-400 dark:border-danger-800'
+                          : 'bg-success-50 text-success-700 border border-success-200 dark:bg-success-900/20 dark:text-success-400 dark:border-success-800'
                       }`}
                     >
                       {message}

--- a/components/FooterComponent.tsx
+++ b/components/FooterComponent.tsx
@@ -11,18 +11,18 @@ const FooterComponent = () => {
   return (
     <footer className='relative mt-auto pt-12 pb-8 p-6 w-full'>
       <div className='w-full max-w-7xl mx-auto'>
-        <hr className='mb-8 border-gray-200 dark:border-border sm:mx-auto' />
+        <hr className='mb-8 border-ink-200 dark:border-border sm:mx-auto' />
         <div className='flex justify-center mb-8'>
           <BackToTop />
         </div>
         <div className='w-full flex flex-col items-center gap-6 sm:flex-row sm:justify-between'>
-          <span className='text-sm text-gray-500 dark:text-gray-400 font-mono'>
+          <span className='text-sm text-ink-500 dark:text-ink-400 font-mono'>
             &copy; {YEAR} Yunior Batista
           </span>
 
           <a
             href={`mailto:${EMAIL}`}
-            className='text-sm text-gray-500 hover:text-primary-600 dark:text-gray-400 dark:hover:text-primary-300 transition-colors font-mono'
+            className='text-sm text-ink-500 hover:text-primary-600 dark:text-ink-400 dark:hover:text-primary-300 transition-colors font-mono'
           >
             {EMAIL}
           </a>
@@ -33,7 +33,7 @@ const FooterComponent = () => {
               target='_blank'
               rel='noopener noreferrer'
               aria-label="Link to Yunior's LinkedIn profile"
-              className='text-gray-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
+              className='text-ink-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
             >
               <BsLinkedin className='h-5 w-5' />
             </a>
@@ -42,7 +42,7 @@ const FooterComponent = () => {
               target='_blank'
               rel='noopener noreferrer'
               aria-label="Link to Yunior's GitHub profile"
-              className='text-gray-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
+              className='text-ink-500 hover:text-primary-600 dark:hover:text-primary-300 transition-colors'
             >
               <BsGithub className='h-5 w-5' />
             </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -50,7 +50,7 @@ I care about creating accessible, maintainable component systems that solve real
           <div className='my-6 hero-anim hero-anim-3'>
             <span
               data-testid='hero-title'
-              className='text-transparent bg-linear-to-r from-blue-200 via-violet-200 to-indigo-200 bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
+              className='text-transparent bg-linear-to-r from-hero-gradient-start via-hero-gradient-mid to-hero-gradient-end bg-clip-text text-xl sm:text-2xl md:text-3xl font-semibold drop-shadow-lg'
             >
               Senior Frontend Engineer
             </span>
@@ -65,8 +65,8 @@ I care about creating accessible, maintainable component systems that solve real
 
           <div className='mt-6 flex items-center gap-2 hero-anim hero-anim-4'>
             <span className='relative flex h-2.5 w-2.5'>
-              <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-75'></span>
-              <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-emerald-400'></span>
+              <span className='absolute inline-flex h-full w-full animate-ping rounded-full bg-live opacity-75'></span>
+              <span className='relative inline-flex h-2.5 w-2.5 rounded-full bg-live'></span>
             </span>
             <span className='text-sm text-white/70 font-mono'>
               Available for new opportunities

--- a/components/LighthouseBadge.tsx
+++ b/components/LighthouseBadge.tsx
@@ -32,10 +32,10 @@ const LighthouseBadge = ({
         className='h-4 w-4 shrink-0 text-primary-600 dark:text-primary-300'
         aria-hidden='true'
       />
-      <span className='font-mono text-xs uppercase tracking-[0.08em] text-gray-500 dark:text-gray-400'>
+      <span className='font-mono text-xs uppercase tracking-[0.08em] text-ink-500 dark:text-ink-400'>
         Lighthouse
       </span>
-      <span className='hidden h-4 w-px bg-gray-300 dark:bg-gray-600 sm:block' />
+      <span className='hidden h-4 w-px bg-ink-300 dark:bg-ink-600 sm:block' />
       <ul className='flex items-center gap-2 font-mono text-xs'>
         {scores.map(({ label, value }) => (
           <li
@@ -43,8 +43,8 @@ const LighthouseBadge = ({
             className='flex items-center gap-1'
             title={`${label}: ${value}/100`}
           >
-            <span className='text-gray-600 dark:text-gray-400'>{label}</span>
-            <span className='font-semibold text-gray-800 dark:text-gray-100'>
+            <span className='text-ink-600 dark:text-ink-400'>{label}</span>
+            <span className='font-semibold text-ink-800 dark:text-ink-100'>
               {value}
             </span>
           </li>

--- a/components/ModeToggle.tsx
+++ b/components/ModeToggle.tsx
@@ -28,7 +28,7 @@ export function ModeToggle({ onHero = false }: { onHero?: boolean }) {
       aria-label={isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
       aria-pressed={isDarkMode}
       onClick={toggleTheme}
-      className='w-6 h-6 flex items-center justify-center cursor-pointer transition:ease-in-out hover:scale-110 duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/60 rounded'
+      className='w-6 h-6 flex items-center justify-center cursor-pointer transition:ease-in-out hover:scale-110 duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-info-500/60 rounded'
     >
       {isDarkMode ? (
         <BsSunFill size={15} className='text-white' />

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -23,10 +23,10 @@ const Navigation = () => {
   // so it goes transparent with light ink to blend with the hero surface. Once
   // scrolled it switches to the frosted, theme-aware look.
   const navSurface = scrolled
-    ? 'bg-white/90 dark:bg-night/90 backdrop-blur-md border-b border-gray-200/40 dark:border-border'
+    ? 'bg-white/90 dark:bg-night/90 backdrop-blur-md border-b border-ink-200/40 dark:border-border'
     : 'bg-transparent border-b border-transparent';
   const linkColor = scrolled
-    ? 'text-gray-700 dark:text-gray-400'
+    ? 'text-ink-700 dark:text-ink-400'
     : 'text-white/90';
   const linkHover = scrolled
     ? 'hover:text-primary-600 dark:hover:text-primary-300 hover:border-primary-500'
@@ -50,7 +50,7 @@ const Navigation = () => {
             type='button'
             className={`inline-flex items-center rounded-lg p-2 text-sm focus:outline-none focus:ring-2 md:hidden ${
               scrolled
-                ? 'text-gray-500 hover:bg-gray-100 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600'
+                ? 'text-ink-500 hover:bg-ink-100 focus:ring-ink-200 dark:text-ink-400 dark:hover:bg-ink-700 dark:focus:ring-ink-600'
                 : 'text-white/80 hover:bg-white/10 focus:ring-white/40'
             }`}
             aria-controls='navbar-collapse'
@@ -100,7 +100,9 @@ const Navigation = () => {
                 onClick={handleNavLinkClick}
                 className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
+                <span
+                  className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}
+                >
                   How I Build
                 </span>
               </a>
@@ -112,7 +114,9 @@ const Navigation = () => {
                 onClick={handleNavLinkClick}
                 className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
+                <span
+                  className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}
+                >
                   Some Projects I&apos;ve Built
                 </span>
               </a>
@@ -124,7 +128,9 @@ const Navigation = () => {
                 onClick={handleNavLinkClick}
                 className={`block py-2 pr-4 pl-3 md:p-0 ${linkColor}`}
               >
-                <span className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}>
+                <span
+                  className={`pb-1 hover:border-b-2 hover:border-spacing-4 ${linkHover}`}
+                >
                   Let&apos;s Connect
                 </span>
               </a>

--- a/components/Project.tsx
+++ b/components/Project.tsx
@@ -52,10 +52,10 @@ const Project = memo(
             </div>
             <div className='md:col-span-5 p-8 flex flex-col justify-center gap-4 relative'>
               <span className='eyebrow'>// Featured</span>
-              <h3 className='fluid-subtitle text-2xl md:text-3xl font-bold tracking-tight text-gray-900 dark:text-white'>
+              <h3 className='fluid-subtitle text-2xl md:text-3xl font-bold tracking-tight text-ink-900 dark:text-white'>
                 {name}
               </h3>
-              <p className='text-gray-700 dark:text-gray-300 text-sm leading-relaxed line-clamp-4'>
+              <p className='text-ink-700 dark:text-ink-300 text-sm leading-relaxed line-clamp-4'>
                 {description}
               </p>
               {impact && (

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -14,10 +14,10 @@ const Projects = async () => {
     >
       <div className='flex flex-col items-center mb-16'>
         <p className='eyebrow'>// 02 · Work</p>
-        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+        <h2 className='fluid-title text-ink-900 dark:text-white mt-4 text-center'>
           Selected Projects
         </h2>
-        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
+        <p className='mt-4 max-w-2xl text-center text-ink-600 dark:text-ink-400 text-sm sm:text-base leading-6'>
           A few things I&apos;ve designed and built. Each card links to a full
           case study of the problem, decisions, and outcome.
         </p>

--- a/components/Skeleton.tsx
+++ b/components/Skeleton.tsx
@@ -6,11 +6,11 @@ const Skeleton = () => {
     >
       <div
         role='status'
-        className='w-11/12 lg:w-10/12 xl:w-1/2 items-center p-4 border border-gray-200 rounded shadow animate-pulse md:p-6 dark:border-gray-700 flex flex-col'
+        className='w-11/12 lg:w-10/12 xl:w-1/2 items-center p-4 border border-ink-200 rounded shadow animate-pulse md:p-6 dark:border-ink-700 flex flex-col'
       >
         <div className='flex items-center mt-4 justify-center mb-3 rounded-full'>
           <svg
-            className='w-20 h-20 me-3 text-gray-200 dark:text-gray-700'
+            className='w-20 h-20 me-3 text-ink-200 dark:text-ink-700'
             aria-hidden='true'
             xmlns='http://www.w3.org/2000/svg'
             fill='currentColor'
@@ -20,16 +20,16 @@ const Skeleton = () => {
           </svg>
         </div>
 
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-32 mb-4 text-center'></div>
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-56 mb-4 text-center'></div>
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-72 text-center'></div>
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-68 text-center'></div>
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-60 text-center mb-2'></div>
-        <div className='h-2.5 bg-gray-200 rounded-full dark:bg-gray-700 w-56 text-center mb-2'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-32 mb-4 text-center'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-56 mb-4 text-center'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-72 text-center'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-68 text-center'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-60 text-center mb-2'></div>
+        <div className='h-2.5 bg-ink-200 rounded-full dark:bg-ink-700 w-56 text-center mb-2'></div>
         <span className='sr-only'>Loading...</span>
         <div className='grid grid-cols-1 md:grid-cols-2 grid-rows-2 md:grid-rows-1 gap-3 grid-flow-col max-w-xl mt-5'>
-          <button className='h-10 w-32 bg-gray-200 rounded-full dark:bg-gray-700' />
-          <button className='h-10 w-32 bg-gray-200 rounded-full dark:bg-gray-700' />
+          <button className='h-10 w-32 bg-ink-200 rounded-full dark:bg-ink-700' />
+          <button className='h-10 w-32 bg-ink-200 rounded-full dark:bg-ink-700' />
         </div>
       </div>
     </section>

--- a/components/Toolbox.tsx
+++ b/components/Toolbox.tsx
@@ -60,10 +60,10 @@ const Toolbox = () => {
     >
       <div className='flex flex-col items-center mb-16'>
         <p className='eyebrow'>// 01 · Skills</p>
-        <h2 className='fluid-title text-gray-900 dark:text-white mt-4 text-center'>
+        <h2 className='fluid-title text-ink-900 dark:text-white mt-4 text-center'>
           How I build
         </h2>
-        <p className='mt-4 max-w-2xl text-center text-gray-600 dark:text-gray-400 text-sm sm:text-base leading-6'>
+        <p className='mt-4 max-w-2xl text-center text-ink-600 dark:text-ink-400 text-sm sm:text-base leading-6'>
           A practical toolkit for shipping reliable, human-first web products —
           from architecture and accessibility through performance and delivery.
         </p>
@@ -87,10 +87,10 @@ const Toolbox = () => {
             <div className='w-11 h-11 rounded-xl bg-linear-to-br from-primary-600 to-violet-a flex items-center justify-center mb-5 text-white shadow-lg shadow-primary-500/20'>
               <skill.icon className='w-5 h-5' />
             </div>
-            <h3 className='fluid-subtitle text-base font-semibold text-gray-900 dark:text-white'>
+            <h3 className='fluid-subtitle text-base font-semibold text-ink-900 dark:text-white'>
               {skill.title}
             </h3>
-            <p className='mt-2 text-sm text-gray-600 dark:text-gray-400 leading-6'>
+            <p className='mt-2 text-sm text-ink-600 dark:text-ink-400 leading-6'>
               {skill.description}
             </p>
           </div>

--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,0 +1,41 @@
+/* Color constants for non-CSS contexts that cannot consume CSS custom
+   properties: the Satori-rendered OG image (app/og-preview/route.tsx) and
+   the transactional contact email (app/api/contact/route.ts). The OG values
+   mirror the CSS tokens in app/styles/variables.css; the email palette is
+   intentionally bespoke (its own gradient brand) and preserved verbatim. */
+
+export const ogColors = {
+  backgroundStart: '#07090f',
+  backgroundMid: '#111623',
+  backgroundEnd: '#1e1b4b',
+  title: '#a5b4fc',
+  body: '#cbd5e1',
+};
+
+export const emailColors = {
+  gradientPrimary: '#667eea',
+  gradientSecondary: '#764ba2',
+  gradientAccent: '#f093fb',
+  heading: '#2d3748',
+  muted: '#718096',
+  label: '#4a5568',
+  fieldBackgroundStart: '#f7fafc',
+  fieldBackgroundEnd: '#edf2f7',
+  messageBackgroundStart: '#f8fafc',
+  messageBackgroundEnd: '#e2e8f0',
+  footer: '#a0aec0',
+  shadowStrong: 'rgba(0,0,0,0.2)',
+  shadowSoft: 'rgba(0,0,0,0.1)',
+  ctaGlow: 'rgba(102, 126, 234, 0.3)',
+};
+
+/* Composite gradients reused across the email template, derived from the
+   palette above so a single source drives the bespoke email brand. */
+export const emailGradients = {
+  brand: `linear-gradient(135deg, ${emailColors.gradientPrimary} 0%, ${emailColors.gradientSecondary} 100%)`,
+  brandAccent: `linear-gradient(90deg, ${emailColors.gradientPrimary} 0%, ${emailColors.gradientSecondary} 50%, ${emailColors.gradientAccent} 100%)`,
+  brandAccentCorner: `linear-gradient(135deg, ${emailColors.gradientPrimary} 0%, ${emailColors.gradientSecondary} 50%, ${emailColors.gradientAccent} 100%)`,
+  avatarSecondary: `linear-gradient(135deg, ${emailColors.gradientSecondary} 0%, ${emailColors.gradientAccent} 100%)`,
+  field: `linear-gradient(135deg, ${emailColors.fieldBackgroundStart} 0%, ${emailColors.fieldBackgroundEnd} 100%)`,
+  message: `linear-gradient(135deg, ${emailColors.messageBackgroundStart} 0%, ${emailColors.messageBackgroundEnd} 100%)`,
+};


### PR DESCRIPTION
## Summary

Centralize every color on the portfolio into design tokens:

- **`app/styles/variables.css`** (new): single `@theme` source of truth — moved existing tokens (primary, violet, night, surface, raised, border, light-surface) plus new semantic scales: `ink-*`, `info-*`, `danger-*`, `success-*`, `live`, `hero-gradient-*`, `hero-bg-*`, `hero-glow-*`, `glass-*`, `brand-tint-*`, `shadow-*`.
- **`lib/colors.ts`** (new): `ogColors` (mirrors CSS tokens), `emailColors` + `emailGradients` (preserves the bespoke email palette verbatim).
- **`app/styles/globals.css`**: imports `variables.css`, removes the inline `@theme` + dead `:root`, body uses `text-body-text dark:text-body-text-dark`, all rgba/hex moved to `var(--...)`.
- **All components/pages** migrated from palette utilities (gray/blue/red/green/emerald/indigo/violet-*, arbitrary [#...]) to semantic tokens.
- **Routes**: `app/og-preview/route.tsx` and `app/api/contact/route.ts` consume `lib/colors.ts` (relative imports per repo convention).

## Verification

- `npm run build` — all 10 routes green.
- `npx jest --watchAll=false` — 14/14 pass, 4 suites.
- Prettier clean on all touched TS/TSX + variables.css.
- **Pixel diff** vs pre-change baseline (Playwright, 1280x900, dark + light):
  - `/resume` and `/projects/portfolio`: byte-identical in both themes.
  - `/` home: only animation-frame residuals (hero gradient + reveal) — token colors match exactly.
  - 404: only residual is the external merakiui illustration load (pre-existing, present in baseline log too).

No visual regression: rendered colors are byte-identical.
