### PR TITLE
chore: gitignore Playwright MCP artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ nul
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+.playwright-mcp/


### PR DESCRIPTION
## What

Adds `.playwright-mcp/` to `.gitignore` so the 62-file / 7.1MB artifact directory created by the Playwright MCP browser tooling stops showing up as untracked clutter in `git status`.

## Why

These are regenerable test artifacts (page snapshots, console logs, baseline/after screenshots) and were never meant to be tracked.

## Test plan

- `git status` on the branch shows only the intended `.gitignore` change.
